### PR TITLE
utilize SolutionDir variable for nuget probing

### DIFF
--- a/source/targets/OctoPack.targets
+++ b/source/targets/OctoPack.targets
@@ -93,6 +93,7 @@
         <FindNuGet Include="$(OctopusProjectRoot)\..\.nuget\NuGet*.exe" />
         <FindNuGet Include="$(OctopusProjectRoot)\..\..\packages\OctoPack*\tools\NuGet.exe" />
         <FindNuGet Include="$(OctopusProjectRoot)\..\..\.nuget\NuGet*.exe" />
+        <FindNuGet Include="$(SolutionDir)\.nuget\NuGet*.exe" />
     </ItemGroup>
     
     <PropertyGroup>        


### PR DESCRIPTION
I've projects in solution in a folder hierarchy with more than 3 levels.
The probing for nuget fails for this projects.
By utilizing SolutionDir variable I could process those projects too.
