### PR TITLE
package only files generated by current project

### DIFF
--- a/source/targets/OctoPack.targets
+++ b/source/targets/OctoPack.targets
@@ -140,8 +140,8 @@
     <MakeDir Directories="$(OctopusTemporaryDirectory)" />
 
     <ItemGroup>
-      <ContentToPackage Include="$(OutputPath)\**\*" Exclude="*.nupkg" />
-      <ContentToPackage Include="$(OutDir)\**\*" Exclude="*.nupkg" />
+      <ContentToPackage Include="$(FileWrites)" Exclude="$(IntermediateOutputPath)**\*" />
+      <ContentToPackage Include="$(FileWritesShareable)" Exclude="$(IntermediateOutputPath)**\*" />
     </ItemGroup>
     <Copy 
       SourceFiles="@(ContentToPackage)"


### PR DESCRIPTION
This way I could work around the problem reported in support forum http://help.octopusdeploy.com/discussions/problems/505-all-binaries-from-tfs-build-in-nuget-package
