### PR TITLE
Install-Package to multiple projects

### DIFF
--- a/source/tools/Install.ps1
+++ b/source/tools/Install.ps1
@@ -35,7 +35,7 @@ function Get-RelativePath ( $folder, $filePath )
 
 function Install-Targets ( $project, $importFile )
 {
-    $buildProject = Get-MSBuildProject
+    $buildProject = Get-MSBuildProject $project.Name
 
     $buildProject.Xml.Imports | Where-Object { $_.Project -match "OctoPack" } | foreach-object {     
         Write-Host ("Removing old import:      " + $_.Project)


### PR DESCRIPTION
Fixes a bug whereby the OctoPack.targets is only imported to the Package Manager Console Default Project's *proj file instead of all projects specified in a piped
Install-Package cmdlet invocation. Similar behavior exhibited when using Visual Studio's Manage Nuget Packages for Solution and selecting multiple projects for installation.

Example: Get-Project WebApp\* | Install-Package OctoPack
