### PR TITLE
Commandline arguments to pass along to NuGet

### DIFF
--- a/source/OctoPack.Tasks/CreateOctoPackPackage.cs
+++ b/source/OctoPack.Tasks/CreateOctoPackPackage.cs
@@ -89,6 +89,11 @@ namespace OctoPack.Tasks
         public string NuGetExePath { get; set; }
 
         /// <summary>
+        /// Extra arguments to pass along to nuget.
+        /// </summary>
+        public string NuGetArguments { get; set; }
+
+        /// <summary>
         /// Properties to pass along to nuget
         /// </summary>
         [Output]
@@ -184,6 +189,7 @@ namespace OctoPack.Tasks
             LogMessage("PackageVersion: " + PackageVersion, MessageImportance.Low);
             LogMessage("ProjectName: " + ProjectName, MessageImportance.Low);
             LogMessage("PrimaryOutputAssembly: " + PrimaryOutputAssembly, MessageImportance.Low);
+            LogMessage("NugetArguments: " + NuGetArguments, MessageImportance.Low);
             LogMessage("NugetProperties: " + NuGetProperties, MessageImportance.Low);
             LogMessage("---------------", MessageImportance.Low);
         }
@@ -381,6 +387,10 @@ namespace OctoPack.Tasks
             if (!string.IsNullOrWhiteSpace(PackageVersion))
             {
                 commandLine += " -Version " + PackageVersion;
+            }
+
+            if (!string.IsNullOrWhiteSpace(NuGetArguments)) {
+                commandLine += " " + NuGetArguments;
             }
 
             if (!string.IsNullOrWhiteSpace(NuGetProperties)) {

--- a/source/targets/OctoPack.targets
+++ b/source/targets/OctoPack.targets
@@ -22,6 +22,7 @@
     <OctoPackPublishPackageToHttp Condition="'$(OctoPackPublishPackageToHttp)' == ''"></OctoPackPublishPackageToHttp>
     <OctoPackPublishApiKey Condition="'$(OctoPackPublishApiKey)' == ''"></OctoPackPublishApiKey>
     <OctoPackPackageVersion Condition="'$(OctoPackPackageVersion)' == ''"></OctoPackPackageVersion>
+    <OctoPackNuGetArguments Condition="'$(OctoPackNuGetArguments)' == ''"></OctoPackNuGetArguments>
     <OctoPackNugetProperties Condition="'$(OctoPackNuGetProperties)' == ''"></OctoPackNugetProperties>
   </PropertyGroup>
 
@@ -54,6 +55,7 @@
       PrimaryOutputAssembly="$(TargetPath)"
       ReleaseNotesFile="$(OctoPackReleaseNotesFile)"
       NuGetExePath="$(OctoPackNuGetExePath)"
+      NuGetArguments="$(OctoPackNuGetArguments)"
       NuGetProperties="$(OctoPackNuGetProperties)"
       >
       <Output TaskParameter="Packages" ItemName="OctoPackBuiltPackages" />


### PR DESCRIPTION
I've added a NuGetArguments property to the CreateOctoPackPackage task, with which you can specify extra NuGet arguments that OctoPack should use when it calls NuGet Pack.

I've used it to pass along -NoDefaultExcludes, so that folders and files starting with a dot are included.

Please tell me if there's anything I should do/add to make this pull request more mergable :)
