### PR TITLE
If we set NuGetProperties, it gets output twice!

### DIFF
--- a/source/OctoPack.Tasks/CreateOctoPackPackage.cs
+++ b/source/OctoPack.Tasks/CreateOctoPackPackage.cs
@@ -387,10 +387,6 @@ namespace OctoPack.Tasks
                 commandLine += " -Properties " + NuGetProperties;
             }
 
-            if (!string.IsNullOrWhiteSpace(NuGetProperties)) {
-                commandLine += " -Properties " + NuGetProperties;
-            }
-
             LogMessage("NuGet.exe path: " + NuGetExePath, MessageImportance.Low);
             LogMessage("Running NuGet.exe with command line arguments: " + commandLine, MessageImportance.Low);
 


### PR DESCRIPTION
This gives us errors like "Invalid option value: '-Properties Configuration=Debug'" from NuGet..
