### PR TITLE
Remove explicit exclusion of Web.Debug.config from web app packaging

### DIFF
--- a/source/OctoPack.Tasks/CreateOctoPackPackage.cs
+++ b/source/OctoPack.Tasks/CreateOctoPackPackage.cs
@@ -121,7 +121,6 @@ namespace OctoPack.Tasks
                     var content =
                         from file in ContentFiles
                         where !string.Equals(Path.GetFileName(file.ItemSpec), "packages.config", StringComparison.OrdinalIgnoreCase)
-                        where !string.Equals(Path.GetFileName(file.ItemSpec), "web.debug.config", StringComparison.OrdinalIgnoreCase)
                         select file;
 
                     var binaries =

--- a/source/OctoPack.Tests/Integration/SampleSolutionBuildFixture.cs
+++ b/source/OctoPack.Tests/Integration/SampleSolutionBuildFixture.cs
@@ -30,7 +30,8 @@ namespace OctoPack.Tests.Integration
                     "Views\\*.cshtml",
                     "Global.asax",
                     "Web.config",
-                    "Web.Release.config"));
+                    "Web.Release.config",
+                    "Web.Debug.config"));
 
             AssertPackage(@"Sample.WebAppWithSpec\obj\octopacked\Sample.WebAppWithSpec.1.0.9.nupkg",
                 pkg => pkg.AssertContents(
@@ -46,7 +47,8 @@ namespace OctoPack.Tests.Integration
                     "Views\\*.cshtml",
                     "Global.asax",
                     "Web.config",
-                    "Web.Release.config"));
+                    "Web.Release.config",
+                    "Web.Debug.config"));
         }
 
         [Test]
@@ -124,7 +126,8 @@ namespace OctoPack.Tests.Integration
                     "Views\\*.cshtml",
                     "Global.asax",
                     "Web.config",
-                    "Web.Release.config"));
+                    "Web.Release.config",
+                    "Web.Debug.config"));
         }
 
         [Test]


### PR DESCRIPTION
Removed exclusion of web.debug.config from packaging as discussed here: http://help.octopusdeploy.com/discussions/questions/1255-how-to-include-webdebugconfig-with-octopack
