### PR TITLE
Added GetAssemblyVersionInfo task (Issue #28)

### DIFF
--- a/source/OctoPack.Tasks/GetAssemblyVersionInfo.cs
+++ b/source/OctoPack.Tasks/GetAssemblyVersionInfo.cs
@@ -1,0 +1,67 @@
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace OctoPack.Tasks
+{
+    public class GetAssemblyVersionInfo : AbstractTask
+    {
+
+        /// <summary>
+        /// Specifies the files the retrieve info from.
+        /// </summary>
+        [Required]
+        public ITaskItem[] AssemblyFiles { get; set; }
+
+        /// <summary>
+        /// Contains the retrieved version info
+        /// </summary>
+        [Output]
+        public ITaskItem[] AssemblyVersionInfo { get; set; }
+
+        public GetAssemblyVersionInfo()
+        {
+
+        }
+
+        public override bool Execute()
+        {
+            if (AssemblyFiles.Length <= 0)
+            {
+                return false;
+            }
+            List<ITaskItem> infos = new List<ITaskItem>();
+            foreach (ITaskItem assemblyFile in AssemblyFiles)
+            {
+                LogMessage(String.Format("Assembly: {0}", assemblyFile.ItemSpec), MessageImportance.Normal);
+                infos.Add(CreateTaskItemFromFileVersionInfo(FileVersionInfo.GetVersionInfo(assemblyFile.ItemSpec)));
+            }
+            AssemblyVersionInfo = infos.ToArray();
+            return true;
+        }
+
+        private static TaskItem CreateTaskItemFromFileVersionInfo(FileVersionInfo info)
+        {
+            var properties =
+                from property in info.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                select new
+                {
+                    Name = property.Name,
+                    Value = property.GetValue(info, null)
+                };
+
+            Hashtable metadata = new Hashtable();
+            foreach (var property in properties)
+            {
+                metadata.Add(property.Name, property.Value.ToString());
+            }
+            return new TaskItem(info.ProductName, metadata);
+        }
+    }
+}

--- a/source/OctoPack.Tasks/OctoPack.Tasks.csproj
+++ b/source/OctoPack.Tasks/OctoPack.Tasks.csproj
@@ -42,6 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AbstractTask.cs" />
+    <Compile Include="GetAssemblyVersionInfo.cs" />
     <Compile Include="CreateOctoPackPackage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SilentProcessRunner.cs" />

--- a/source/targets/OctoPack.targets
+++ b/source/targets/OctoPack.targets
@@ -1,5 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask TaskName="OctoPack.Tasks.CreateOctoPackPackage" AssemblyFile="OctoPack.Tasks.dll" />
+  <UsingTask TaskName="OctoPack.Tasks.GetAssemblyVersionInfo" AssemblyFile="OctoPack.Tasks.dll" />
 
   <!-- Hook into the AfterBuild activity -->
   <PropertyGroup>
@@ -32,6 +33,12 @@
     <GetAssemblyIdentity AssemblyFiles="$(TargetPath)">
       <Output TaskParameter="Assemblies" ItemName="AssemblyIdentities"/>
     </GetAssemblyIdentity>
+    <GetAssemblyVersionInfo AssemblyFiles="$(TargetPath)">
+      <Output TaskParameter="AssemblyVersionInfo" ItemName="AssemblyVersions"/>
+    </GetAssemblyVersionInfo>
+    <PropertyGroup>
+      <OctoPackPackageVersion Condition="'$(OctoPackPackageVersion)' == ''">%(AssemblyVersions.ProductVersion)</OctoPackPackageVersion>
+    </PropertyGroup>
     <PropertyGroup>
       <OctoPackPackageVersion Condition="'$(OctoPackPackageVersion)' == ''">%(AssemblyIdentities.Version)</OctoPackPackageVersion>
     </PropertyGroup>


### PR DESCRIPTION
Added GetAssemblyVersionInfo task to get extended properties from the
assembly to be deployed, and updated the OctoPack targets to use it to
get the Informational version. This enables, among other things, the
ability to create packages with Prerelease tags. This should close issue #28.
