### PR TITLE
Support NuGet install for .NET 3.5 projects

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -56,6 +56,7 @@ task Package -depends Build {
 	write-host "Package"
 
     mkdir .\build\content
+    mkdir .\build\content\net35
     mkdir .\build\content\net40
     mkdir .\build\content\netcore45
     mkdir .\build\tools


### PR DESCRIPTION
Got this error when installing the latest OctoPack for a .NET 3.5 project.

> Could not install package 'OctoPack 3.0.20'. You are trying to install this package into a project that targets '.NETFramework,Version=v3.5', but the package does not contain any assembly references or content files that are compatible with tha
> t framework. For more information, contact the package author.

Version 2 supported projects targeting .NET 3.5 and I didn't see any documentation saying support had been dropped so I tested this quick fix to get it installed.
