### PR TITLE
Option to disable publishing to Team City

### DIFF
--- a/source/OctoPack.Tasks/CreateOctoPackPackage.cs
+++ b/source/OctoPack.Tasks/CreateOctoPackPackage.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Security.Cryptography;
-using System.Threading;
 using System.Xml.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -102,6 +99,8 @@ namespace OctoPack.Tasks
 
 
         public bool EnforceAddingFiles { get; set; }
+
+        public bool PublishPackagesToTeamCity { get; set; }        
 
         /// <summary>
         /// Extra arguments to pass along to nuget.
@@ -478,7 +477,7 @@ namespace OctoPack.Tasks
 
                 Copy(new[] { file }, packageOutput, OutDir);
 
-                if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("TEAMCITY_VERSION")))
+                if (PublishPackagesToTeamCity && !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("TEAMCITY_VERSION")))
                 {
                     LogMessage("##teamcity[publishArtifacts '" + file + "']");
                 }

--- a/source/tools/OctoPack.targets
+++ b/source/tools/OctoPack.targets
@@ -29,6 +29,7 @@
     <OctoPackNugetProperties Condition="'$(OctoPackNuGetProperties)' == ''"></OctoPackNugetProperties>
     <OctoPackEnforceAddingFiles Condition="'$(OctoPackEnforceAddingFiles)' == ''">false</OctoPackEnforceAddingFiles>
     <OctoPackNuGetPushProperties Condition="'$(OctoPackNuGetPushProperties)' == ''"></OctoPackNuGetPushProperties>
+    <OctoPackPublishPackagesToTeamCity Condition="'$(OctoPackPublishPackagesToTeamCity)' == ''">true</OctoPackPublishPackagesToTeamCity>
   </PropertyGroup>
 
   <!-- 
@@ -70,6 +71,7 @@
       NuGetArguments="$(OctoPackNuGetArguments)"
       NuGetProperties="$(OctoPackNuGetProperties)"
       EnforceAddingFiles="$(OctoPackEnforceAddingFiles)"
+      PublishPackagesToTeamCity="$(OctoPackPublishPackagesToTeamCity)"
       WrittenFiles="@(OctoPackWrittenFiles)"
       IncludeTypeScriptSourceFiles="$(OctoPackIncludeTypeScriptSourceFiles)"
       >


### PR DESCRIPTION
Added option to disable publishing to Team City.
OctoPackPublishPackagesToTeamCity  is set to true by default and setting
it to false will disable the publishing.
