### PR TITLE
Add append project option to nuget publish feed

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -104,3 +104,4 @@ To publish your package to a NuGet feed, you can optionally use some extra MSBui
  - `/p:OctoPackPublishPackageToFileShare=C:\MyPackages` - copies the package to the path given
  - `/p:OctoPackPublishPackageToHttp=http://my-nuget-server/api/v2/package` - pushes the package to the NuGet server
  - `/p:OctoPackPublishApiKey=ABCDEFGMYAPIKEY` - API key to use when publishing
+ - `/p:OctoPackAppendProjectToFeed=true` - Append the project name onto the feed so you can nest packages under folders on publish

--- a/source/tools/OctoPack.targets
+++ b/source/tools/OctoPack.targets
@@ -98,6 +98,6 @@
     <Copy SourceFiles="@(OctoPackBuiltPackages)" DestinationFolder="$(OctoPackPublishPackageToFileShare)" Condition="'$(OctoPackPublishPackageToFileShare)' != ''" />
 
     <Message Text="Publish to repository: $(OctoPackPublishPackageToHttp)" Condition="'$(OctoPackPublishPackageToHttp)' != ''" Importance="Normal" />
-    <Exec Command='"$(OctoPackNuGetExePath)" push "@(OctoPackBuiltPackages)" $(OctoPackPublishApiKey) -s $(OctoPackPublishPackageToHttp) $(OctoPackNuGetPushProperties)' Condition="'$(OctoPackPublishPackageToHttp)' != ''"/>
+    <Exec Command='"$(OctoPackNuGetExePath)" push "@(OctoPackBuiltPackages)" $(OctoPackPublishApiKey) -s $(OctoPackPublishPackageToHttp) $(OctoPackNuGetPushProperties)' Condition="'$(OctoPackPublishPackageToHttp)' != ''" />
   </Target>
 </Project>


### PR DESCRIPTION
The purpose of this feature is so that people can push to in house nuget repos and have more control over the organization.  For example artifactory allows you to push to a custom nuget path lets say:

```
http://artifactory/api/nuget/nuget-local/[orgName]/[packageName]/[packageName].[version].nupkg
```

This allows artifactory to create a folder structure for better package management.
