### PR TITLE
Fixes VSO OctoPack website xmldoc failure

### DIFF
--- a/source/tools/OctoPack.targets
+++ b/source/tools/OctoPack.targets
@@ -55,8 +55,13 @@
     <Message Text="Using package version: $(OctoPackPackageVersion)" />
 
     <ItemGroup>
-      <OctoPackWrittenFiles Include="@(FileWrites)" Exclude="$(IntermediateOutputPath)**\*" />
-      <OctoPackWrittenFiles Include="@(FileWritesShareable)" Exclude="$(IntermediateOutputPath)**\*" />
+      <OctoPackWrittenFiles Include="%(FileWrites.FullPath)" Exclude="$(IntermediateOutputPath)**\*" />
+      <OctoPackWrittenFiles Include="%(FileWritesShareable.FullPath)" Exclude="$(IntermediateOutputPath)**\*" />
+      
+      <!-- Filter out any OctoPackWrittenFiles that is a solution or intermediate file -->
+      <IgnoredFiles Include="$(SolutionDir)**\*" Exclude="$(TargetDir)**\*" />
+      <OctoPackWrittenFiles Remove="%(IgnoredFiles.FullPath)" />
+      
       <OctoPackContentFiles Include="@(Content)" />
       <OctoPackContentFiles Include="@(TypeScriptCompile)" />
     </ItemGroup>


### PR DESCRIPTION
@(FileWrites) for a website that has xmldoc enabled and is built on VSO fails when Nuget packaging executes. This is because the [Project].XML is included in @(FileWrites) as both a source file and target file and is added to the Nuget package for the same output path.

This change needs to cater for local development where the target directory is under the source directory, and other build configurations (like TFS and VSO) where the target directory is not under the source directory. In either case, we need to explicitly remove any solution file from @(FileWrites) while maintaining any target file where it happens to be under the solution root. For example, VSO has a SolutionDir of C:\a\src\ and a TargetDir of C:\a\bin\ whereas local development would be something like a SolutionDir of C:\Project\ and a TargetDir of C:\Project\bin.

One of the issues found in this solution was updating the exclusion of OctoPackWrittenFiles did not work because the solution paths were not found when using the Exclude attribute. The workaround here is to populate OctoPackWrittenFiles using %(Set.FullPath) rather than @(Set). This then allows a Remove to correctly match on the full file path rather than other string representations of the same logical path (like \* or ..\ paths).

The next issue is that we can only remove solution directory files that are not target directory files. This means that something like $(SolutionDir)*_\_ can't be added to the Exclude attribute of OctoPackwrittenFiles. The solution here is to first build a list of entries to remove. By building this list, we take the solution files and exclude any target files. This is the set that is then explicitly removed from OctoPackWrittenFiles.

This now works both locally and on VSO. The VSO build can now build and publish a package for the website.
