### PR TITLE
Add cli Property to append value to package id

### DIFF
--- a/source/OctoPack.Tasks/CreateOctoPackPackage.cs
+++ b/source/OctoPack.Tasks/CreateOctoPackPackage.cs
@@ -37,6 +37,11 @@ namespace OctoPack.Tasks
         public string NuSpecFileName { get; set; }
 
         /// <summary>
+        /// Appends the value to <see cref="ProjectName"/> when generating the Id of the Nuget Package
+        /// </summary>
+        public string AppendToPackageId { get; set; }
+
+        /// <summary>
         /// The list of content files in the project. For web applications, these files will be included in the final package.
         /// </summary>
         [Required]
@@ -239,6 +244,13 @@ namespace OctoPack.Tasks
             if (fileSystem.FileExists(specFilePath))
                 return specFilePath;
 
+            var packageId = RemoveTrailing(ProjectName, ".csproj", ".vbproj");
+
+            if (!string.IsNullOrWhiteSpace(AppendToPackageId))
+            {
+                packageId = string.Format("{0}.{1}", packageId, AppendToPackageId.Trim());
+            }
+
             LogMessage(string.Format("A NuSpec file named '{0}' was not found in the project root, so the file will be generated automatically. However, you should consider creating your own NuSpec file so that you can customize the description properly.", specFileName));
 
             var manifest =
@@ -247,7 +259,7 @@ namespace OctoPack.Tasks
                         "package",
                         new XElement(
                             "metadata",
-                            new XElement("id", RemoveTrailing(ProjectName, ".csproj", ".vbproj")),
+                            new XElement("id", packageId),
                             new XElement("version", PackageVersion),
                             new XElement("authors", Environment.UserName),
                             new XElement("owners", Environment.UserName),

--- a/source/OctoPack.Tests/Integration/SampleSolutionBuildFixture.cs
+++ b/source/OctoPack.Tests/Integration/SampleSolutionBuildFixture.cs
@@ -244,5 +244,53 @@ namespace OctoPack.Tests.Integration
                     "web.config",
                     "SomeFiles\\Foo.css"));
         }
+
+        [Test]
+        public void ShouldAllowAppendingValueToPackageId()
+        {
+            MsBuild("Samples.sln /p:RunOctoPack=true /p:OctoPackPackageVersion=1.0.9 /p:OctoPackAppendToPackageId=Foo /p:Configuration=Release /v:m");
+
+            AssertPackage(@"Sample.ConsoleApp\obj\octopacked\Sample.ConsoleApp.Foo.1.0.9.nupkg",
+                pkg => pkg.AssertContents(
+                    "Sample.ConsoleApp.exe",
+                    "Sample.ConsoleApp.exe.config",
+                    "Sample.ConsoleApp.pdb"));
+
+            AssertPackage(@"Sample.WebApp\obj\octopacked\Sample.WebApp.Foo.1.0.9.nupkg",
+                pkg => pkg.AssertContents(
+                    "bin\\*.dll",
+                    "bin\\*.xml",
+                    "bin\\Sample.WebApp.dll",
+                    "bin\\Sample.WebApp.pdb",
+                    "Content\\*.css",
+                    "Content\\*.png",
+                    "Content\\LinkedFile.txt",
+                    "Scripts\\*.js",
+                    "Views\\Web.config",
+                    "Views\\*.cshtml",
+                    "Global.asax",
+                    "Web.config",
+                    "Web.Release.config",
+                    "Web.Debug.config"));
+
+            AssertPackage(@"Sample.WebAppWithSpec\obj\octopacked\Sample.WebAppWithSpec.1.0.9.nupkg",
+                pkg => pkg.AssertContents(
+                    "bin\\*.dll",
+                    "bin\\*.xml",
+                    "bin\\Sample.WebAppWithSpec.dll",
+                    "bin\\Sample.WebAppWithSpec.pdb",
+                    "Content\\*.css",
+                    "Content\\*.png",
+                    "Content\\LinkedFile.txt",
+                    "Scripts\\*.js",
+                    "Views\\Web.config",
+                    "Views\\*.cshtml",
+                    "Views\\Deploy.ps1",
+                    "Deploy.ps1",
+                    "Global.asax",
+                    "Web.config",
+                    "Web.Release.config",
+                    "Web.Debug.config"));
+        }
     }
 }

--- a/source/tools/OctoPack.targets
+++ b/source/tools/OctoPack.targets
@@ -19,6 +19,7 @@
     <RunOctoPack Condition="'$(RunOctoPack)'==''">false</RunOctoPack>
     <OctoPackIncludeTypeScriptSourceFiles Condition="'$(OctoPackIncludeTypeScriptSourceFiles)'==''">false</OctoPackIncludeTypeScriptSourceFiles>
     <OctoPackNuSpecFileName Condition="'$(OctoPackNuSpecFileName)' == ''"></OctoPackNuSpecFileName>
+    <OctoPackAppendToPackageId Condition="'$(OctoPackAppendToPackageId)' == ''"></OctoPackAppendToPackageId>
     <OctoPackReleaseNotesFile Condition="'$(OctoPackReleaseNotesFile)' == ''"></OctoPackReleaseNotesFile>
     <OctoPackNuGetExePath Condition="'$(OctoPackNuGetExePath)' == ''"></OctoPackNuGetExePath>
     <OctoPackPublishPackageToFileShare Condition="'$(OctoPackPublishPackageToFileShare)' == ''"></OctoPackPublishPackageToFileShare>
@@ -63,6 +64,7 @@
     
     <CreateOctoPackPackage
       NuSpecFileName="$(OctoPackNuSpecFileName)"
+      AppendToPackageId="$(OctoPackAppendToPackageId)"
       ContentFiles="@(OctoPackContentFiles)"
       OutDir="$(OutDir)"
       ProjectDirectory="$(MSBuildProjectDirectory)"


### PR DESCRIPTION
In the scenario where multiple branches (for different environments, like
master, dev, staging) have their packages built using octopack, and they
are published to the same nuget feed (e.g. they are all being pushed to
Teamcity's nuget feed), the packages will end up having the same id, which
will cause Octopus to pull the wrong package.

This property allow the user to pass in some arbirtrary value, the
environment name for example, to the msbuild task so that it can
differentiate the packages being generated.
