### PR TITLE
Mark OctoPack as a development dependency.

### DIFF
--- a/source/OctoPack.nuspec
+++ b/source/OctoPack.nuspec
@@ -15,6 +15,7 @@
       Octopus Deploy is an automated deployment tool powered by NuGet. This tool adds a post-build activity to your Visual Studio project, so that an Octopus-compatible NuGet package is produced in the Bin directory whenever a Release build completes.
     </description>
     <tags>automation deployment</tags>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
     <file src="content*" target="content" />


### PR DESCRIPTION
Since OctoPack is only required at build time it should not be included in the list of dependencies for a referencing projects nuspec. From the [nuspec reference](http://docs.nuget.org/docs/reference/nuspec-reference):

> This will cause the package to be excluded from the dependency list when the referencing project itself is later packaged.
