### PR TITLE
Fix for Issue #1354 (OctoPackAppendToPackageId)

### DIFF
--- a/source/OctoPack.Tasks/CreateOctoPackPackage.cs
+++ b/source/OctoPack.Tasks/CreateOctoPackPackage.cs
@@ -145,6 +145,7 @@ namespace OctoPack.Tasks
                 var specFilePath = GetOrCreateNuSpecFile(octopacking);
                 var specFile = OpenNuSpecFile(specFilePath);
 
+                UpdatePackageIdWithAppendValue(specFile);
                 AddReleaseNotes(specFile);
 
                 OutDir = fileSystem.GetFullPath(OutDir);
@@ -247,11 +248,6 @@ namespace OctoPack.Tasks
 
             var packageId = RemoveTrailing(ProjectName, ".csproj", ".vbproj");
 
-            if (!string.IsNullOrWhiteSpace(AppendToPackageId))
-            {
-                packageId = string.Format("{0}.{1}", packageId, AppendToPackageId.Trim());
-            }
-
             LogMessage(string.Format("A NuSpec file named '{0}' was not found in the project root, so the file will be generated automatically. However, you should consider creating your own NuSpec file so that you can customize the description properly.", specFileName));
 
             var manifest =
@@ -328,6 +324,25 @@ namespace OctoPack.Tasks
             {
                 releaseNotes.Value = notes;
             }
+        }
+
+        private void UpdatePackageIdWithAppendValue(XContainer nuSpec)
+        {
+            if (string.IsNullOrWhiteSpace(AppendToPackageId))
+            {
+                return;
+            }
+
+            var package = nuSpec.ElementAnyNamespace("package");
+            if (package == null) throw new Exception(string.Format("The NuSpec file does not contain a <package> XML element. The NuSpec file appears to be invalid."));
+
+            var metadata = package.ElementAnyNamespace("metadata");
+            if (metadata == null) throw new Exception(string.Format("The NuSpec file does not contain a <metadata> XML element. The NuSpec file appears to be invalid."));
+
+            var packageId = metadata.ElementAnyNamespace("id");
+            if (packageId == null) throw new Exception(string.Format("The NuSpec file does not contain a <id> XML element. The NuSpec file appears to be invalid."));
+
+            packageId.Value = string.Format("{0}.{1}", packageId.Value, AppendToPackageId.Trim());
         }
 
         private void AddFiles(XContainer nuSpec, IEnumerable<string> sourceFiles, string sourceBaseDirectory, string targetDirectory = "")

--- a/source/OctoPack.Tests/Integration/SampleSolutionBuildFixture.cs
+++ b/source/OctoPack.Tests/Integration/SampleSolutionBuildFixture.cs
@@ -273,7 +273,7 @@ namespace OctoPack.Tests.Integration
                     "Web.Release.config",
                     "Web.Debug.config"));
 
-            AssertPackage(@"Sample.WebAppWithSpec\obj\octopacked\Sample.WebAppWithSpec.1.0.9.nupkg",
+            AssertPackage(@"Sample.WebAppWithSpec\obj\octopacked\Sample.WebAppWithSpec.Foo.1.0.9.nupkg",
                 pkg => pkg.AssertContents(
                     "bin\\*.dll",
                     "bin\\*.xml",


### PR DESCRIPTION
Implemented a fix to allow the OctoPackAppendToPackageId command-line parameter to be used for projects that include a NuSpec file.

The previous modification of the Project Id was refactored out to a specific method and moved to later in the process such that it could apply whether an existing NuSpec file was available or not.

The `ShouldAllowAppendingValueToPackageId` test was also updated to allow for the new functionality.
