### PR TITLE
The tests doesn't work on vs2013, vs2015 preview since msbuild is part of vs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ tools/TestResult.xml
 packages
 source/Samples/Notes.txt
 source/Samples/.octopack
+
+# vs 2015 preview
+*.sln.ide/
+

--- a/source/OctoPack.Tests/Integration/BuildFixture.cs
+++ b/source/OctoPack.Tests/Integration/BuildFixture.cs
@@ -6,6 +6,9 @@ using NUnit.Framework;
 using NuGet;
 using OctoPack.Tasks;
 using OctoPack.Tasks.Util;
+using Microsoft.Build.Utilities;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace OctoPack.Tests.Integration
 {
@@ -36,10 +39,31 @@ namespace OctoPack.Tests.Integration
             MsBuild(commandLineArguments, null );
         }
 
-        protected static void MsBuild(string commandLineArguments, Action<string> outputValidator)
+        private static IEnumerable<string> VsMsBuildPaths()
+        {
+            var tryVersions = new[] { "14.0", "12.0" };// 11?
+            foreach (var version in tryVersions)
+            {
+                var location = ToolLocationHelper.GetPathToBuildToolsFile(
+"msbuild.exe", version,
+DotNetFrameworkArchitecture.Bitness64);
+                if (location != null)
+                    yield return location;
+            }
+        }
+
+        private static string FrameworkMsbuild()
         {
             var netFx = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
             var msBuild = Path.Combine(netFx, "msbuild.exe");
+            return msBuild;
+        }
+
+        protected static void MsBuild(string commandLineArguments, Action<string> outputValidator)
+        {
+            var vsMsBuild = VsMsBuildPaths().FirstOrDefault(path=>File.Exists(path));
+
+            var msBuild = vsMsBuild!=null ? vsMsBuild : FrameworkMsbuild();
             if (!File.Exists(msBuild))
             {
                 Assert.Fail("Could not find MSBuild at: " + msBuild);

--- a/source/OctoPack.Tests/OctoPack.Tests.csproj
+++ b/source/OctoPack.Tests/OctoPack.Tests.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OctoPack.Tests</RootNamespace>
     <AssemblyName>OctoPack.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -22,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -30,8 +32,10 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Build.Utilities.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.Web.XmlTransform">
       <HintPath>..\packages\Microsoft.Web.Xdt.1.0.0\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>


### PR DESCRIPTION
I tried to run the tests using vs2013 and vs2015 preview. This does not work since the location of where msbuild is installed has [changed after visual studio 2013](http://blogs.msdn.com/b/visualstudio/archive/2013/07/24/msbuild-is-now-part-of-visual-studio.aspx).

The change ensures that OctoPack BuildFixture can find relevant msbuild.