### PR TITLE
Add double quotes around NuGet's Properties

### DIFF
--- a/source/OctoPack.Tasks/CreateOctoPackPackage.cs
+++ b/source/OctoPack.Tasks/CreateOctoPackPackage.cs
@@ -529,7 +529,7 @@ namespace OctoPack.Tasks
 
             if (!string.IsNullOrWhiteSpace(NuGetProperties))
             {
-                commandLine += " -Properties " + NuGetProperties;
+                commandLine += " -Properties \"" + NuGetProperties + "\"";
             }
 
             if (!string.IsNullOrWhiteSpace(NuGetArguments)) {


### PR DESCRIPTION
Adds support for special characters in properties (spaces, etc...).

TFS's build server will supply the build requester, which I wanted in the Author property of the package.  However, the name contains a space and a comma, breaking OctoPack.

I did find a work-around.  Using double quotes within the NugGetProperties parameters will pass through to the NuGet command:

/p:OctoPackNuGetProperties="\"author=Smith, John\""