### PR TITLE
Added OctoPackAppendToVersion parameter.

### DIFF
--- a/source/OctoPack.Tasks/CreateOctoPackPackage.cs
+++ b/source/OctoPack.Tasks/CreateOctoPackPackage.cs
@@ -43,6 +43,11 @@ namespace OctoPack.Tasks
         public string AppendToPackageId { get; set; }
 
         /// <summary>
+        /// Appends the value to the version.
+        /// </summary>
+        public string AppendToVersion { get; set; }
+
+        /// <summary>
         /// The list of content files in the project. For web applications, these files will be included in the final package.
         /// </summary>
         [Required]
@@ -146,6 +151,7 @@ namespace OctoPack.Tasks
                 var specFile = OpenNuSpecFile(specFilePath);
 
                 UpdatePackageIdWithAppendValue(specFile);
+                UpdateVersionWithAppendValue(specFile);
                 AddReleaseNotes(specFile);
 
                 OutDir = fileSystem.GetFullPath(OutDir);
@@ -345,6 +351,24 @@ namespace OctoPack.Tasks
             packageId.Value = string.Format("{0}.{1}", packageId.Value, AppendToPackageId.Trim());
         }
 
+        private void UpdateVersionWithAppendValue(XContainer nuSpec)
+        {
+            if (string.IsNullOrWhiteSpace(AppendToVersion))
+            {
+                return;
+            }
+
+            var package = nuSpec.ElementAnyNamespace("package");
+            if (package == null) throw new Exception(string.Format("The NuSpec file does not contain a <package> XML element. The NuSpec file appears to be invalid."));
+
+            var metadata = package.ElementAnyNamespace("metadata");
+            if (metadata == null) throw new Exception(string.Format("The NuSpec file does not contain a <metadata> XML element. The NuSpec file appears to be invalid."));
+
+            var version = metadata.ElementAnyNamespace("version");
+            if (version == null) throw new Exception(string.Format("The NuSpec file does not contain a <version> XML element. The NuSpec file appears to be invalid."));
+
+            version.Value = string.Format("{0}-{1}", version.Value, AppendToVersion.Trim());
+        }
 
         private void AddFiles(XContainer nuSpec, IEnumerable<ITaskItem> sourceFiles, string sourceBaseDirectory, string targetDirectory = "", string relativeTo = "")
         {

--- a/source/OctoPack.Tasks/CreateOctoPackPackage.cs
+++ b/source/OctoPack.Tasks/CreateOctoPackPackage.cs
@@ -368,6 +368,7 @@ namespace OctoPack.Tasks
             if (version == null) throw new Exception(string.Format("The NuSpec file does not contain a <version> XML element. The NuSpec file appears to be invalid."));
 
             version.Value = string.Format("{0}-{1}", version.Value, AppendToVersion.Trim());
+            PackageVersion = version.Value;
         }
 
         private void AddFiles(XContainer nuSpec, IEnumerable<ITaskItem> sourceFiles, string sourceBaseDirectory, string targetDirectory = "", string relativeTo = "")

--- a/source/OctoPack.Tests/Integration/SampleSolutionBuildFixture.cs
+++ b/source/OctoPack.Tests/Integration/SampleSolutionBuildFixture.cs
@@ -294,6 +294,54 @@ namespace OctoPack.Tests.Integration
         }
 
         [Test]
+        public void ShouldAllowAppendingValueToVersion()
+        {
+            MsBuild("Samples.sln /p:RunOctoPack=true /p:OctoPackPackageVersion=1.0.9 /p:OctoPackAppendToVersion=Foo /p:Configuration=Release /v:m");
+
+            AssertPackage(@"Sample.ConsoleApp\obj\octopacked\Sample.ConsoleApp.1.0.9-Foo.nupkg",
+                pkg => pkg.AssertContents(
+                    "Sample.ConsoleApp.exe",
+                    "Sample.ConsoleApp.exe.config",
+                    "Sample.ConsoleApp.pdb"));
+
+            AssertPackage(@"Sample.WebApp\obj\octopacked\Sample.WebApp.Foo.1.0.9-Foo.nupkg",
+                pkg => pkg.AssertContents(
+                    "bin\\*.dll",
+                    "bin\\*.xml",
+                    "bin\\Sample.WebApp.dll",
+                    "bin\\Sample.WebApp.pdb",
+                    "Content\\*.css",
+                    "Content\\*.png",
+                    "Content\\LinkedFile.txt",
+                    "Scripts\\*.js",
+                    "Views\\Web.config",
+                    "Views\\*.cshtml",
+                    "Global.asax",
+                    "Web.config",
+                    "Web.Release.config",
+                    "Web.Debug.config"));
+
+            AssertPackage(@"Sample.WebAppWithSpec\obj\octopacked\Sample.WebAppWithSpec.Foo.1.0.9-Foo.nupkg",
+                pkg => pkg.AssertContents(
+                    "bin\\*.dll",
+                    "bin\\*.xml",
+                    "bin\\Sample.WebAppWithSpec.dll",
+                    "bin\\Sample.WebAppWithSpec.pdb",
+                    "Content\\*.css",
+                    "Content\\*.png",
+                    "Content\\LinkedFile.txt",
+                    "Scripts\\*.js",
+                    "Views\\Web.config",
+                    "Views\\*.cshtml",
+                    "Views\\Deploy.ps1",
+                    "Deploy.ps1",
+                    "Global.asax",
+                    "Web.config",
+                    "Web.Release.config",
+                    "Web.Debug.config"));
+        }
+
+        [Test]
         public void ShouldSupportRelativeOutputDirectories()
         {
             MsBuild("Sample.ConsoleWithRelativeOutDir\\Sample.ConsoleWithRelativeOutDir.csproj /p:RunOctoPack=true /p:OctoPackPackageVersion=1.0.11 /p:Configuration=Release");

--- a/source/tools/OctoPack.targets
+++ b/source/tools/OctoPack.targets
@@ -20,6 +20,7 @@
     <OctoPackIncludeTypeScriptSourceFiles Condition="'$(OctoPackIncludeTypeScriptSourceFiles)'==''">false</OctoPackIncludeTypeScriptSourceFiles>
     <OctoPackNuSpecFileName Condition="'$(OctoPackNuSpecFileName)' == ''"></OctoPackNuSpecFileName>
     <OctoPackAppendToPackageId Condition="'$(OctoPackAppendToPackageId)' == ''"></OctoPackAppendToPackageId>
+    <OctoPackAppendToVersion Condition="'$(OctoPackAppendToVersion)' == ''"></OctoPackAppendToVersion>
     <OctoPackReleaseNotesFile Condition="'$(OctoPackReleaseNotesFile)' == ''"></OctoPackReleaseNotesFile>
     <OctoPackNuGetExePath Condition="'$(OctoPackNuGetExePath)' == ''"></OctoPackNuGetExePath>
     <OctoPackPublishPackageToFileShare Condition="'$(OctoPackPublishPackageToFileShare)' == ''"></OctoPackPublishPackageToFileShare>
@@ -74,6 +75,7 @@
     <CreateOctoPackPackage
       NuSpecFileName="$(OctoPackNuSpecFileName)"
       AppendToPackageId="$(OctoPackAppendToPackageId)"
+      AppendToVersion="$(OctoPackAppendToVersion)"
       ContentFiles="@(OctoPackContentFiles)"
       OutDir="$(OutDir)"
       ProjectDirectory="$(MSBuildProjectDirectory)"


### PR DESCRIPTION
We need to have the ability to append a pre-release tag to the package cersion, say for the CI build number.
I've added this parameter and unit -test to OctoPack but don't seem to be able to run any of the unit tests at all to confirm it's validity.