### PR TITLE
Added targets property for OctoPackOutDir

### DIFF
--- a/source/tools/OctoPack.targets
+++ b/source/tools/OctoPack.targets
@@ -31,6 +31,7 @@
     <OctoPackEnforceAddingFiles Condition="'$(OctoPackEnforceAddingFiles)' == ''">false</OctoPackEnforceAddingFiles>
     <OctoPackNuGetPushProperties Condition="'$(OctoPackNuGetPushProperties)' == ''"></OctoPackNuGetPushProperties>
     <OctoPackPublishPackagesToTeamCity Condition="'$(OctoPackPublishPackagesToTeamCity)' == ''">true</OctoPackPublishPackagesToTeamCity>
+    <OctoPackOutDir Condition="'$(OctoPackOutDir)' == ''">$(OutDir)</OctoPackOutDir>
     <OctoPackProjectName Condition="'$(OctoPackProjectName)' == ''">$(MSBuildProjectName)</OctoPackProjectName>
     <OctoPackIgnoreNonRootScripts Condition="'$(OctoPackIgnoreNonRootScripts)' == ''">false</OctoPackIgnoreNonRootScripts>
     <OctoPackAppConfigFileOverride Condition="'$(OctoPackAppConfigFileOverride)' == ''">$(TargetDir)$(TargetFileName).config</OctoPackAppConfigFileOverride>
@@ -75,7 +76,7 @@
       NuSpecFileName="$(OctoPackNuSpecFileName)"
       AppendToPackageId="$(OctoPackAppendToPackageId)"
       ContentFiles="@(OctoPackContentFiles)"
-      OutDir="$(OutDir)"
+      OutDir="$(OctoPackOutDir)"
       ProjectDirectory="$(MSBuildProjectDirectory)"
       ProjectName="$(OctoPackProjectName)"
       PackageVersion="$(OctoPackPackageVersion)"


### PR DESCRIPTION
This is useful when you want to change the output directory of the generated packages especially when using the `GenerateProjectSpecificOutputFolder` MSBUILD property.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/octopusdeploy/octopack/68)
<!-- Reviewable:end -->
