### PR TITLE
Gitversion compatibility

### DIFF
--- a/source/OctoPack.Tasks/GetAssemblyVersionInfo.cs
+++ b/source/OctoPack.Tasks/GetAssemblyVersionInfo.cs
@@ -45,12 +45,22 @@ namespace OctoPack.Tasks
 
         private static TaskItem CreateTaskItemFromFileVersionInfo(string path)
         {
+            var assembly = Assembly.LoadFrom(path);
             var info = FileVersionInfo.GetVersionInfo(path);
-            var currentAssemblyName = AssemblyName.GetAssemblyName(info.FileName);
-
+            var currentAssemblyName = assembly.GetName();
             var assemblyVersion = currentAssemblyName.Version;
             var assemblyFileVersion = info.FileVersion;
             var assemblyVersionInfo = info.ProductVersion;
+            var nugetVersion = assembly.GetNugetVersion();
+
+            if (nugetVersion != null)
+            {
+                // If we find a GitVersion information in the assembly, we can be pretty sure it's got the stuff we want, so let's use that.
+                return new TaskItem(info.FileName, new Hashtable
+                {
+                    { "Version", nugetVersion },
+                });
+            }
 
             if (assemblyFileVersion == assemblyVersionInfo)
             {

--- a/source/OctoPack.Tasks/Util/AssemblyExtensions.cs
+++ b/source/OctoPack.Tasks/Util/AssemblyExtensions.cs
@@ -1,11 +1,10 @@
 ﻿using System;
-using System.IO;
 using System.Linq;
 using System.Reflection;
 
 // ReSharper disable CheckNamespace
 public static class AssemblyExtensions
-// ReSharper restore CheckNamespace
+    // ReSharper restore CheckNamespace
 {
     public static string FullLocalPath(this Assembly assembly)
     {
@@ -16,8 +15,19 @@ public static class AssemblyExtensions
         return root;
     }
 
+
     public static string GetFileVersion(this Assembly assembly)
     {
         return assembly.GetCustomAttributes(true).OfType<AssemblyFileVersionAttribute>().First().Version;
+    }
+
+
+    public static string GetNugetVersion(this Assembly assembly)
+    {
+        var gitVersionInformationType = assembly.GetType("GitVersionInformation");
+        if (gitVersionInformationType == null)
+            return null;
+        var versionField = gitVersionInformationType.GetField("NuGetVersion");
+        return (string)versionField.GetValue(null);
     }
 }

--- a/source/OctoPack.Tests/OctoPack.Tests.csproj
+++ b/source/OctoPack.Tests/OctoPack.Tests.csproj
@@ -32,6 +32,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Web.XmlTransform">
       <HintPath>..\packages\Microsoft.Web.Xdt.1.0.0\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
@@ -55,6 +56,7 @@
   <ItemGroup>
     <Compile Include="Integration\BuildFixture.cs" />
     <Compile Include="Integration\SampleSolutionBuildFixture.cs" />
+    <Compile Include="Tasks\AssemblyExtensionsTests.cs" />
     <Compile Include="Util\ZipPackageExtensions.cs" />
     <Compile Include="Tasks\OctopusPhysicalFileSystemTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/source/OctoPack.Tests/Properties/AssemblyInfo.cs
+++ b/source/OctoPack.Tests/Properties/AssemblyInfo.cs
@@ -34,3 +34,10 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[CompilerGenerated]
+static class GitVersionInformation
+{
+    public static string NuGetVersion = "1.1.1-tests";
+}
+

--- a/source/OctoPack.Tests/Tasks/AssemblyExtensionsTests.cs
+++ b/source/OctoPack.Tests/Tasks/AssemblyExtensionsTests.cs
@@ -1,0 +1,26 @@
+﻿using System.Reflection;
+
+using NUnit.Framework;
+
+using OctoPack.Tasks;
+
+namespace OctoPack.Tests.Tasks
+{
+    [TestFixture]
+    public class AssemblyExtensionsTests
+    {
+        [Test]
+        public void AssertAssemblyVersionGetsGitVersion()
+        {
+            string gitversion = Assembly.GetAssembly(typeof(AssemblyExtensionsTests)).GetNugetVersion();
+            Assert.That(gitversion, Is.EqualTo("1.1.1-tests"));
+        }
+
+        [Test]
+        public void AssertAssemblyVersion_WhereNoGitVersionProperty_ReturnsNull()
+        {
+            string gitversion = Assembly.GetAssembly(typeof(GetAssemblyVersionInfo)).GetNugetVersion();
+            Assert.That(gitversion, Is.Null);
+        }
+    }
+}


### PR DESCRIPTION
This PR enables compatability with [GitVersionTasks](https://github.com/GitTools/GitVersion).

The version number, when using GitVersionTasks, comes from a msbuild step, i.e after we can override the OctoPackPackageVersion.

This PR checks for the special types GitVersion adds to the versioned assembly, and uses the "NuGetVersion" as its main source of truth.

Relevant discussions:
OctopusDeploy/OctoPack#60
https://twitter.com/jakeginnivan/status/584236410984652800

Other workaround:
http://www.neovolve.com/2015/04/04/bridging-gitversion-and-octopack/
