### PR TITLE
Option to force OctoPack to use file version

### DIFF
--- a/source/OctoPack.Tasks/GetAssemblyVersionInfo.cs
+++ b/source/OctoPack.Tasks/GetAssemblyVersionInfo.cs
@@ -19,7 +19,6 @@ namespace OctoPack.Tasks
         [Required]
         public ITaskItem[] AssemblyFiles { get; set; }
 
-
         /// <summary>
         /// Contains the retrieved version info
         /// </summary>
@@ -37,7 +36,6 @@ namespace OctoPack.Tasks
             foreach (var assemblyFile in AssemblyFiles)
             {
                 LogMessage(String.Format("Get version info from assembly: {0}", assemblyFile), MessageImportance.Normal);
-
 
                 infos.Add(CreateTaskItemFromFileVersionInfo(assemblyFile.ItemSpec));
             }

--- a/source/OctoPack.Tasks/GetAssemblyVersionInfo.cs
+++ b/source/OctoPack.Tasks/GetAssemblyVersionInfo.cs
@@ -19,6 +19,7 @@ namespace OctoPack.Tasks
         [Required]
         public ITaskItem[] AssemblyFiles { get; set; }
 
+
         /// <summary>
         /// Contains the retrieved version info
         /// </summary>
@@ -37,13 +38,16 @@ namespace OctoPack.Tasks
             {
                 LogMessage(String.Format("Get version info from assembly: {0}", assemblyFile), MessageImportance.Normal);
 
+
                 infos.Add(CreateTaskItemFromFileVersionInfo(assemblyFile.ItemSpec));
             }
             AssemblyVersionInfo = infos.ToArray();
             return true;
         }
 
-        private static TaskItem CreateTaskItemFromFileVersionInfo(string path)
+        public bool UseFileVersion { get; set; }
+
+        private TaskItem CreateTaskItemFromFileVersionInfo(string path)
         {
             var info = FileVersionInfo.GetVersionInfo(path);
             var currentAssemblyName = AssemblyName.GetAssemblyName(info.FileName);
@@ -51,6 +55,14 @@ namespace OctoPack.Tasks
             var assemblyVersion = currentAssemblyName.Version;
             var assemblyFileVersion = info.FileVersion;
             var assemblyVersionInfo = info.ProductVersion;
+
+            if (UseFileVersion)
+            {
+                return new TaskItem(info.FileName, new Hashtable
+                {
+                    {"Version", assemblyFileVersion },
+                });
+            }
 
             if (assemblyFileVersion == assemblyVersionInfo)
             {

--- a/source/tools/OctoPack.targets
+++ b/source/tools/OctoPack.targets
@@ -35,13 +35,14 @@
     <OctoPackIgnoreNonRootScripts Condition="'$(OctoPackIgnoreNonRootScripts)' == ''">false</OctoPackIgnoreNonRootScripts>
     <OctoPackAppConfigFileOverride Condition="'$(OctoPackAppConfigFileOverride)' == ''">$(TargetDir)$(TargetFileName).config</OctoPackAppConfigFileOverride>
     <OctoPackAppendProjectToFeed Condition="'$(OctoPackAppendProjectToFeed)' == ''">false</OctoPackAppendProjectToFeed>
+    <UseFileVersion Condition="'$(UseFileVersion)' == ''">false</UseFileVersion>
   </PropertyGroup>
 
   <!-- 
   Create Octopus Deploy package
   -->
   <Target Name="OctoPack" Condition="$(RunOctoPack)">
-    <GetAssemblyVersionInfo AssemblyFiles="$(TargetPath)" Condition="'$(OctoPackPackageVersion)' == ''">
+    <GetAssemblyVersionInfo UseFileVersion="$(UseFileVersion)" AssemblyFiles="$(TargetPath)" Condition="'$(OctoPackPackageVersion)' == ''">
       <Output TaskParameter="AssemblyVersionInfo" ItemName="AssemblyVersions"/>
     </GetAssemblyVersionInfo>
     <PropertyGroup>


### PR DESCRIPTION
When using gitflow with git versioning task, OctoPack is not able to create nuget packages cause of the invalid version number (e.g. 1.5.0-unstable.94+94.Branch.develop.Sha.a.......). OctoPack uses by default the product version. The only way to overrule this, is to set the version with OctoPackPackageVersion. This PR adds an option to force OctoPack to use the file version.