### PR TITLE
Enables multiple rebuilds from within Visual Studio.

### DIFF
--- a/source/OctoPack.Tasks/GetAssemblyVersionInfo.cs
+++ b/source/OctoPack.Tasks/GetAssemblyVersionInfo.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -115,12 +116,14 @@ namespace OctoPack.Tasks
 
         private static string GetNuGetVersionFromGitVersionInformation(string path)
         {
-            var assembly = Assembly.LoadFrom(path);
+            // Visual Studio runs msbuild with an unsual set of parameters "/nodemode:1 /nodeReuse:true" which cause msbuild to stay
+            // running after the build process is finished. This means that if we load the assembly directly (e.g. Assemply.Load) then 
+            // the assembly will be locked and no furthre re-builds will be possible.
+            var copy = File.ReadAllBytes(path);
+            var assembly = Assembly.Load(copy);
             var nugetVersion = assembly.GetNugetVersionFromGitVersionInformation();
-
             return nugetVersion;
         }
-
     }
 
     internal class VersionNotFoundException : Exception

--- a/source/OctoPack.Tests/Integration/SampleSolutionBuildFixture.cs
+++ b/source/OctoPack.Tests/Integration/SampleSolutionBuildFixture.cs
@@ -102,6 +102,18 @@ namespace OctoPack.Tests.Integration
         }
 
         [Test]
+        public void ShouldPreferGitVersionTheMost()
+        {
+            MsBuild("Sample.ConsoleAppWithGitVersion\\Sample.ConsoleAppWithGitVersion.csproj /p:RunOctoPack=true /p:Configuration=Release /v:m");
+
+            AssertPackage(@"Sample.ConsoleAppWithGitVersion\obj\octopacked\Sample.ConsoleAppWithGitVersion.1.4.0.nupkg",
+                pkg => pkg.AssertContents(
+                    "Sample.ConsoleAppWithGitVersion.exe",
+                    "Sample.ConsoleAppWithGitVersion.exe.config",
+                    "Sample.ConsoleAppWithGitVersion.pdb"));
+        }
+
+        [Test]
         public void ShouldBuildWithSpecAndAssemblyInformationalVersion()
         {
             MsBuild("Sample.WebAppWithSpec\\Sample.WebAppWithSpec.csproj /p:RunOctoPack=true /p:Configuration=Release /v:m");

--- a/source/Samples/Sample.ConsoleAppWithGitVersion/App.config
+++ b/source/Samples/Sample.ConsoleAppWithGitVersion/App.config
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+</configuration>

--- a/source/Samples/Sample.ConsoleAppWithGitVersion/Program.cs
+++ b/source/Samples/Sample.ConsoleAppWithGitVersion/Program.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Sample.ConsoleAppWithGitVersion
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+        }
+    }
+}

--- a/source/Samples/Sample.ConsoleAppWithGitVersion/Properties/AssemblyInfo.cs
+++ b/source/Samples/Sample.ConsoleAppWithGitVersion/Properties/AssemblyInfo.cs
@@ -1,0 +1,16 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Sample.ConsoleAppWithGitVersion")]
+[assembly: AssemblyVersion("2.1.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
+
+[CompilerGenerated]
+static class GitVersionInformation
+{
+    public static string NuGetVersion = "1.4.0";
+}

--- a/source/Samples/Sample.ConsoleAppWithGitVersion/Sample.ConsoleAppWithGitVersion.csproj
+++ b/source/Samples/Sample.ConsoleAppWithGitVersion/Sample.ConsoleAppWithGitVersion.csproj
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{6C0A7990-22B3-4D9E-B4F5-10ED2D73B734}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Sample.ConsoleAppWithGitVersion</RootNamespace>
+    <AssemblyName>Sample.ConsoleAppWithGitVersion</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <Import Project="..\.octopack\Octopack.targets" />
+</Project>

--- a/source/Samples/Sample.ConsoleAppWithGitVersion/Sample.ConsoleAppWithGitVersion.csproj.teamcity
+++ b/source/Samples/Sample.ConsoleAppWithGitVersion/Sample.ConsoleAppWithGitVersion.csproj.teamcity
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{77368AC2-07C1-4EB9-9575-327823B2240F}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Sample.ConsoleAppWithGitVersion</RootNamespace>
+    <AssemblyName>Sample.ConsoleAppWithGitVersion</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\Sample.ConsoleAppWithGitVersion2\App.config">
+      <Link>App.config</Link>
+    </None>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <Import Project="..\.octopack\Octopack.targets" />
+</Project>

--- a/source/Samples/Samples.sln
+++ b/source/Samples/Samples.sln
@@ -30,6 +30,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample.WebAppWithLinkedWebC
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample.WebAppWithLinkedWebConfigInSubfolder", "Sample.WebAppWithLinkedWebConfigInSubfolder\Sample.WebAppWithLinkedWebConfigInSubfolder.csproj", "{9B052925-A182-4ABA-8839-B38C442B600F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample.ConsoleAppWithGitVersion", "Sample.ConsoleAppWithGitVersion\Sample.ConsoleAppWithGitVersion.csproj", "{6C0A7990-22B3-4D9E-B4F5-10ED2D73B734}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -76,6 +78,10 @@ Global
 		{9B052925-A182-4ABA-8839-B38C442B600F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9B052925-A182-4ABA-8839-B38C442B600F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9B052925-A182-4ABA-8839-B38C442B600F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6C0A7990-22B3-4D9E-B4F5-10ED2D73B734}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C0A7990-22B3-4D9E-B4F5-10ED2D73B734}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6C0A7990-22B3-4D9E-B4F5-10ED2D73B734}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6C0A7990-22B3-4D9E-B4F5-10ED2D73B734}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Fixes OctopusDeploy/Issues/issues/2556.

Visual Studio runs msbuild with an unsual set of parameters "/nodemode:1 /nodeReuse:true" which cause msbuild to stay running after the build process is finished. This means that if we load the assembly directly (e.g. Assemply.Load) then the assembly will be locked and no furthre re-builds will be possible. Node moe is not even a documented parameter (https://msdn.microsoft.com/en-us/library/ms164311.aspx)

I could not figure out how to write a test for this sceanario. My guess is that VS start msbuild and then communites with it directly via a TCP connection.
