### PR TITLE
Fall back to assembly file version

### DIFF
--- a/source/OctoPack.Tasks/GetAssemblyVersionInfo.cs
+++ b/source/OctoPack.Tasks/GetAssemblyVersionInfo.cs
@@ -87,11 +87,20 @@ namespace OctoPack.Tasks
             var assemblyFileVersion = info.FileVersion;
             var assemblyVersionInfo = info.ProductVersion;
 
-            if (UseFileVersion)
+            if (UseFileVersion || !assemblyVersionInfo.IsSemanticVersion())
             {
-                LogMessage(
-                    string.Format("Using the assembly file version because UseFileVersion is set: {0}",
-                        assemblyFileVersion), MessageImportance.Normal);
+                if (UseFileVersion)
+                {
+                    LogMessage(
+                        string.Format("Using the assembly file version because UseFileVersion is set: {0}",
+                            assemblyFileVersion), MessageImportance.Normal);
+                }
+                else
+                {
+                    LogMessage(
+                        string.Format("Using the assembly file version because the assembly version ({0}) is not a valid semantic version: {1}",
+                            assemblyVersionInfo, assemblyFileVersion), MessageImportance.Normal);
+                }
                 return new TaskItem(info.FileName, new Hashtable
                 {
                     {"Version", assemblyFileVersion},

--- a/source/OctoPack.Tasks/OctoPack.Tasks.csproj
+++ b/source/OctoPack.Tasks/OctoPack.Tasks.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Util\IOctopusFileSystem.cs" />
     <Compile Include="Util\NumericExtensions.cs" />
     <Compile Include="Util\OctopusPhysicalFileSystem.cs" />
+    <Compile Include="Util\VersionExtensions.cs" />
     <Compile Include="Util\XmlElementExtensions.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/source/OctoPack.Tasks/Util/VersionExtensions.cs
+++ b/source/OctoPack.Tasks/Util/VersionExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System.Text.RegularExpressions;
+
+public static class VersionExtensions
+{
+    const string SemanticVersionPattern = @"(?<semanticVersion>(\d+(\.\d+){0,3}" // Major Minor Patch
+     + @"(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)" // Pre-release identifiers
+     + @"(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)"; // Build Metadata
+
+    public static bool IsSemanticVersion(this string versionString)
+    {
+        var match = Regex.Match(versionString, $@"^{SemanticVersionPattern}$");
+
+        var versionMatch = match.Groups["semanticVersion"];
+
+        return versionMatch.Success;
+    }
+}

--- a/source/OctoPack.Tasks/Util/VersionExtensions.cs
+++ b/source/OctoPack.Tasks/Util/VersionExtensions.cs
@@ -2,13 +2,13 @@
 
 public static class VersionExtensions
 {
-    const string SemanticVersionPattern = @"(?<semanticVersion>(\d+(\.\d+){0,3}" // Major Minor Patch
+    const string SemanticVersionPattern = @"^(?<semanticVersion>(\d+(\.\d+){0,3}" // Major Minor Patch
      + @"(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)" // Pre-release identifiers
-     + @"(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)"; // Build Metadata
+     + @"(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$"; // Build Metadata
 
     public static bool IsSemanticVersion(this string versionString)
     {
-        var match = Regex.Match(versionString, $@"^{SemanticVersionPattern}$");
+        var match = Regex.Match(versionString, SemanticVersionPattern);
 
         var versionMatch = match.Groups["semanticVersion"];
 

--- a/source/OctoPack.Tests/OctoPack.Tests.csproj
+++ b/source/OctoPack.Tests/OctoPack.Tests.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Integration\SampleSolutionBuildFixture.cs" />
     <Compile Include="Tasks\AssemblyExtensionsTests.cs" />
     <Compile Include="Util\PackageArchiveReaderExtensions.cs" />
+    <Compile Include="Tasks\VersionExtensionsTest.cs" />
     <Compile Include="Util\ZipPackageExtensions.cs" />
     <Compile Include="Tasks\OctopusPhysicalFileSystemTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/source/OctoPack.Tests/Tasks/VersionExtensionsTest.cs
+++ b/source/OctoPack.Tests/Tasks/VersionExtensionsTest.cs
@@ -1,0 +1,22 @@
+﻿using NUnit.Framework;
+
+namespace OctoPack.Tests.Tasks
+{
+    [TestFixture]
+    public class VersionExtensionsTest
+    {
+        [Test]
+        [TestCase("1", true)]
+        [TestCase("1.0", true)]
+        [TestCase("1.0.1", true)]
+        [TestCase("1.0.1.5", true)]
+        [TestCase("1.0.0-alpha", true)]
+        [TestCase("test", false)]
+        [TestCase("1.a", false)]
+        public void ShouldParseSemanticVersions(string versionString, bool expected)
+        {
+            var actual = versionString.IsSemanticVersion();
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+    }
+}


### PR DESCRIPTION
Causes OctoPack to fall back to the assembly file version if the assembly version is not a valid semantic version.

Refer to https://github.com/OctopusDeploy/OctoPack/pull/72