### PR TITLE
[WIP] Support NuGet 3.x and project.json

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -72,9 +72,9 @@ task Package -depends Build {
     mkdir .\build\content\net35
     mkdir .\build\content\net40
     mkdir .\build\content\netcore45
-    mkdir .\build\tools
-    dir -recurse .\source\OctoPack.Tasks\bin\$configuration | copy -destination build\tools -Force
-    dir -recurse .\source\tools | copy -destination build\tools -Force
+    mkdir .\build\build
+    dir -recurse .\source\OctoPack.Tasks\bin\$configuration | copy -destination build\build -Force
+    dir -recurse .\source\tools | copy -destination build\build -Force
     Copy-Item .\source\OctoPack.nuspec .\build 
     Copy-Item .\license.txt .\build 
 

--- a/source/OctoPack.nuspec
+++ b/source/OctoPack.nuspec
@@ -20,7 +20,7 @@
   <files>
     <file src="content*" target="content" />
     <file src="content\" target="content\" />
-    <file src="tools\*" target="tools" />
+    <file src="build\*" target="build" />
     <file src="license.txt" target="license.txt" />
   </files>
 </package>


### PR DESCRIPTION
## Progress
- [x] Make sure that NuGet 3.xx is supported
- [ ] Make sure that NuGet 2.xx is still supported

The was an old MR #77 created a long time ago. Unfortunately, after I submitted it the team made some changes in the repository, added new contributing guidelines. 

This MR targets the same issue, but it's implemented according to new guidelines. 

Please see #77 for motivation and additional disscussions.
## How to test:

I have a test solution with two console applications: 
- ConsoleApplication1 
- ConsoleApplication2

First one has a `project.json` file with the following content: 

``` json
{
  "dependencies": {
    "OctoPack": "3.4.2"
  },
  "frameworks": {
    "net46": {}
  },
  "runtimes": {
    "win": {}
  }
}
```

Where the package is taken from the "local" nuget source, not from the nuget.org.

The second one has `packages.config` file: 

``` xml
<?xml version="1.0" encoding="utf-8"?>
<packages>
  <package id="OctoPack" version="3.4.2" targetFramework="net46" developmentDependency="true" />
</packages>
```

By running the command: 

`
 "c:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" /p:RunOctoPack=true
`
I can confirm that both packages are created. 

![screen shot 2016-10-11 at 12 48 45](https://cloud.githubusercontent.com/assets/819053/19267816/1face980-8fb1-11e6-9922-0b43a6b54796.png)

There is no CI configured for this project, so I just can show a screenshot with test runner results :) 

![screen shot 2016-10-11 at 12 21 38](https://cloud.githubusercontent.com/assets/819053/19267742/bf972db2-8fb0-11e6-8bb7-c4638e7d1d79.png)

I don't have NuGet 2.x installed on my machine, however, if needed I can install it and build a test scenario for that. 
