### PR TITLE
Make it possible to separate OctoPack output from regular Nuget-packages

### DIFF
--- a/source/OctoPack.Tasks/CreateOctoPackPackage.cs
+++ b/source/OctoPack.Tasks/CreateOctoPackPackage.cs
@@ -269,6 +269,7 @@ namespace OctoPack.Tasks
                             new XElement("version", PackageVersion),
                             new XElement("authors", Environment.UserName),
                             new XElement("owners", Environment.UserName),
+                            new XElement("tags", "OctopusDeploy"),
                             new XElement("licenseUrl", "http://example.com"),
                             new XElement("projectUrl", "http://example.com"),
                             new XElement("requireLicenseAcceptance", "false"),


### PR DESCRIPTION
In a bigger CI build-pipeline the build-output may include both "regular" Nuget packages (for instance API-packages for partners) and deployment-packages created by Octopack.

In order to process these efficiently in our build pipeline, we need to be able to differ between different kind of packages and how they should be processed:

* some should be sent to a regular Nuget-repository for API consumers.
* some should be sent to Octopus-deploy for deployment.

I'm sure there are other categories as well, but these are the big two categories which I think is cross-cutting through our entire code-base.

We've been maintaining a fork to be able to:

* use AssemblyFileVersion for versioning (you took your time!)
* ensure OctoPack packages are tagged appropriately

Now with the first issue fixed, we'd love to go back to mainline Octopack, but in order to do that we do need the Octopack packages properly tagged. 

One option is to create Nuspec's for each and every project full of redundant information which needs to be manually maintained. Or just fix it in Octopack once and for all. And that's what this PR should address.