### PR TITLE
Report the final output directory as the teamcity artifact location

### DIFF
--- a/source/OctoPack.Tasks/CreateOctoPackPackage.cs
+++ b/source/OctoPack.Tasks/CreateOctoPackPackage.cs
@@ -248,7 +248,7 @@ namespace OctoPack.Tasks
             }
 
             if (fileSystem.FileExists(specFileName))
-                Copy(new[] { Path.Combine(ProjectDirectory, specFileName) }, ProjectDirectory, octopacking);
+                Copy(Path.Combine(ProjectDirectory, specFileName), ProjectDirectory, octopacking);
 
             var specFilePath = Path.Combine(octopacking, specFileName);
             if (fileSystem.FileExists(specFilePath))
@@ -564,20 +564,18 @@ namespace OctoPack.Tasks
             });
         }
 
-        private void Copy(IEnumerable<string> sourceFiles, string baseDirectory, string destinationDirectory)
+        private string Copy(string source, string baseDirectory, string destinationDirectory)
         {
-            foreach (var source in sourceFiles)
-            {
-                var relativePath = fileSystem.GetPathRelativeTo(source, baseDirectory);
-                var destination = Path.Combine(destinationDirectory, relativePath);
+            var relativePath = fileSystem.GetPathRelativeTo(source, baseDirectory);
+            var destination = Path.Combine(destinationDirectory, relativePath);
 
-                LogMessage("Copy file: " + source, importance: MessageImportance.Normal);
+            LogMessage("Copy file: " + source, importance: MessageImportance.Normal);
 
-                var relativeDirectory = Path.GetDirectoryName(destination);
-                fileSystem.EnsureDirectoryExists(relativeDirectory);
+            var relativeDirectory = Path.GetDirectoryName(destination);
+            fileSystem.EnsureDirectoryExists(relativeDirectory);
 
-                fileSystem.CopyFile(source, destination);
-            }
+            fileSystem.CopyFile(source, destination);
+            return destination;
         }
 
         private void FindNuGet()
@@ -632,12 +630,11 @@ namespace OctoPack.Tasks
 
                 var fullPath = Path.Combine(packageOutput, file);
                 packageFiles.Add(CreateTaskItemFromPackage(fullPath));
-
-                Copy(new[] { file }, packageOutput, OutDir);
+                var destination = Copy(file, packageOutput, OutDir);
 
                 if (PublishPackagesToTeamCity && !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("TEAMCITY_VERSION")))
                 {
-                    LogMessage("##teamcity[publishArtifacts '" + file + "']");
+                    LogMessage("##teamcity[publishArtifacts '" + destination + "']");
                 }
             }
 

--- a/source/OctoPack.Tasks/SilentProcessRunner.cs
+++ b/source/OctoPack.Tasks/SilentProcessRunner.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 
@@ -6,7 +7,7 @@ namespace OctoPack.Tasks
 {
     public static class SilentProcessRunner
     {
-        public static int ExecuteCommand(string executable, string arguments, string workingDirectory, Action<string> output, Action<string> error)
+        public static int ExecuteCommand(string executable, string arguments, string workingDirectory, Action<string> output, Action<string> error, Dictionary<string,string> environmentVariables = null)
         {
             try
             {
@@ -19,6 +20,14 @@ namespace OctoPack.Tasks
                     process.StartInfo.CreateNoWindow = true;
                     process.StartInfo.RedirectStandardOutput = true;
                     process.StartInfo.RedirectStandardError = true;
+
+                    if (environmentVariables != null)
+                    {
+                        foreach (var key in environmentVariables.Keys)
+                        {
+                            process.StartInfo.EnvironmentVariables[key] = environmentVariables[key];
+                        }
+                    }
 
                     using (var outputWaitHandle = new AutoResetEvent(false))
                     using (var errorWaitHandle = new AutoResetEvent(false))

--- a/source/OctoPack.Tests/Integration/BuildFixture.cs
+++ b/source/OctoPack.Tests/Integration/BuildFixture.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
@@ -31,12 +32,7 @@ namespace OctoPack.Tests.Integration
             Clean("Sample.WebAppWithSpec\\bin");
         }
 
-        protected static void MsBuild(string commandLineArguments)
-        {
-            MsBuild(commandLineArguments, null );
-        }
-
-        protected static void MsBuild(string commandLineArguments, Action<string> outputValidator)
+        protected static void MsBuild(string commandLineArguments, Action<string> outputValidator = null, Dictionary<string,string> environmentVariables = null)
         {
             var msBuild = GetMsBuildPath();
             var allOutput = new StringBuilder();
@@ -47,17 +43,14 @@ namespace OctoPack.Tests.Integration
                 Console.WriteLine(output);
             };
 
-            var result = SilentProcessRunner.ExecuteCommand(msBuild, commandLineArguments, Environment.CurrentDirectory, writer, e => writer("ERROR: " + e));
+            var result = SilentProcessRunner.ExecuteCommand(msBuild, commandLineArguments, Environment.CurrentDirectory, writer, e => writer("ERROR: " + e), environmentVariables);
 
             if (result != 0)
             {
                 Assert.Fail("MSBuild returned a non-zero exit code: " + result);
             }
 
-            if (outputValidator != null)
-            {
-                outputValidator(allOutput.ToString());
-            }
+            outputValidator?.Invoke(allOutput.ToString());
         }
 
         private static string GetMsBuildPath()

--- a/source/OctoPack.Tests/Integration/SampleSolutionBuildFixture.cs
+++ b/source/OctoPack.Tests/Integration/SampleSolutionBuildFixture.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using NuGet.Versioning;
 using NUnit.Framework;
 
@@ -163,6 +164,14 @@ namespace OctoPack.Tests.Integration
                     "Sample.ConsoleApp.exe",
                     "Sample.ConsoleApp.exe.config",
                     "Sample.ConsoleApp.pdb"));
+        }
+
+        [Test]
+        public void ShouldReportOutDirPackageLocationToTeamCity()
+        {
+            MsBuild("Sample.ConsoleApp\\Sample.ConsoleApp.csproj.teamcity /p:RunOctoPack=true /p:OctoPackPackageVersion=1.0.10 /p:OctoPackPublishPackagesToTeamCity=true /p:Configuration=Release /v:m",
+                output => Assert.That(output, Is.StringMatching(@"##teamcity\[publishArtifacts .*\\bin\\Release\\Sample.ConsoleApp.1.0.10.nupkg'\]")),
+                environmentVariables: new Dictionary<string, string> { { "TEAMCITY_VERSION", "10.0" } });
         }
 
         [Test]


### PR DESCRIPTION
We currently report nuget artifacts to teamcity using the octopacked directory rather than the build output directory. This should be fine most of the time, but one user ran into problems where they where doing multiple builds of the name proj with different configurations.

Fixes: OctopusDeploy/Issues#2742