### PR TITLE
Creates NuGet.exe.config file to add Long Path support.

### DIFF
--- a/source/build/NuGet.exe.config
+++ b/source/build/NuGet.exe.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false;Switch.System.IO.BlockLongPaths=false" />
+  </runtime>
+</configuration>


### PR DESCRIPTION
Allows to avoid PathTooLongException on deep folder hierarchies.