### PR TITLE
[WIP] Add simple dotnet-octo program

### DIFF
--- a/source/OctoPack.sln
+++ b/source/OctoPack.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OctoPack.Tasks", "OctoPack.Tasks\OctoPack.Tasks.csproj", "{BEF74811-0C8D-45D4-B9DE-232795A3A84D}"
 EndProject
@@ -23,6 +23,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Solution Items\SolutionInfo.cs = Solution Items\SolutionInfo.cs
 		Solution Items\VersionInfo.cs = Solution Items\VersionInfo.cs
 	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-octo", "dotnet-octo\dotnet-octo.csproj", "{828A4A12-5678-414D-96CD-2C45CDC3CE3B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -46,8 +48,15 @@ Global
 		{7C18CB5F-1144-4476-83CE-EF387472A5F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7C18CB5F-1144-4476-83CE-EF387472A5F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7C18CB5F-1144-4476-83CE-EF387472A5F6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{828A4A12-5678-414D-96CD-2C45CDC3CE3B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{828A4A12-5678-414D-96CD-2C45CDC3CE3B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{828A4A12-5678-414D-96CD-2C45CDC3CE3B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{828A4A12-5678-414D-96CD-2C45CDC3CE3B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B1EC1AD4-72CC-41D9-946E-DDC854777E7B}
 	EndGlobalSection
 EndGlobal

--- a/source/dotnet-octo/Program.cs
+++ b/source/dotnet-octo/Program.cs
@@ -1,0 +1,181 @@
+﻿namespace OctoPack
+{
+    using System;
+    using System.IO;
+    using System.IO.Compression;
+    using System.Reflection;
+
+    using Microsoft.Extensions.CommandLineUtils;
+
+    using Octopus.Client;
+
+    public static class Program
+    {
+        public static int Main(string[] args)
+        {
+            var app = new CommandLineApplication();
+
+            app.Command("pack", Pack);
+            app.Command("push", Push);
+
+            app.HelpOption("-?|-h|--help");
+
+            if (args.Length == 0)
+            {
+                Console.WriteLine("octo " + GetAssemblyInformationalVersion());
+                app.ShowHelp();
+                return 0;
+            }
+
+            try
+            {
+                return app.Execute(args);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(ex.Message);
+                Console.Error.WriteLine(ex.StackTrace);
+                return -1;
+            }
+        }
+
+        public static void Pack(CommandLineApplication command)
+        {
+            command.Description = "Create a zip file from a folder";
+
+            var idOption = command.Option(
+                "--id",
+                "The ID of the package; e.g MyWebSite",
+                CommandOptionType.SingleValue);
+
+            var versionOption = command.Option(
+                "--version",
+                "The version of the package, must be a valid SemVer",
+                CommandOptionType.SingleValue);
+
+            var sourceDirOption = command.Option(
+                "-s|--source-dir",
+                "Source directory",
+                CommandOptionType.SingleValue);
+
+            var destinationDirOption = command.Option(
+                "-d|--destination-dir",
+                "Destination directory",
+                CommandOptionType.SingleValue);
+
+            var verboseOption = command.Option(
+                "-v|--verbose",
+                "[Optional] Output debug info",
+                CommandOptionType.NoValue);
+
+            command.HelpOption("-?|-h|--help");
+
+            command.OnExecute(
+                () =>
+                {
+                    var sourceDirectoryName = sourceDirOption.Value();
+                    var id = idOption.Value();
+                    var version = versionOption.Value();
+                    var destinationDirectoryName = destinationDirOption.Value();
+                    if (string.IsNullOrWhiteSpace(sourceDirectoryName)
+                        || string.IsNullOrWhiteSpace(id)
+                        || string.IsNullOrWhiteSpace(version)
+                        || string.IsNullOrWhiteSpace(destinationDirectoryName))
+                    {
+                        command.ShowHelp();
+                        return -1;
+                    }
+
+                    var destinationArchiveFileName = Path.Combine(destinationDirectoryName, $"{id}.{version}.zip");
+                    var verbose = verboseOption.Value();
+
+                    if (verbose == "on")
+                    {
+                        Console.WriteLine($"id {id}");
+                        Console.WriteLine($"version {version}");
+                        Console.WriteLine($"source {sourceDirectoryName}");
+                        Console.WriteLine($"destinationDir {destinationDirectoryName}");
+                        Console.WriteLine($"destination {destinationArchiveFileName}");
+                        Console.Out.Flush();
+                    }
+
+                    ZipFile.CreateFromDirectory(sourceDirectoryName, destinationArchiveFileName);
+
+                    return 0;
+                });
+        }
+
+        public static void Push(CommandLineApplication command)
+        {
+            command.Description = "Push a nupkg or zip file to octopus";
+
+            var packageOption = command.Option(
+                "--package",
+                "Package to push",
+                CommandOptionType.SingleValue);
+
+            var serverOption = command.Option(
+                "--server",
+                "The base URL for your octopus server - e.g. http://your-octopus/",
+                CommandOptionType.SingleValue);
+
+            var apiKeyOption = command.Option(
+                "--api-key",
+                "Your API key",
+                CommandOptionType.SingleValue);
+
+            var verboseOption = command.Option(
+                "-v|--verbose",
+                "[Optional] Output debug info",
+                CommandOptionType.NoValue);
+
+            command.HelpOption("-?|-h|--help");
+
+            command.OnExecute(
+                async () =>
+                {
+                    var uriString = serverOption.Value();
+                    var apiKey = apiKeyOption.Value();
+                    var package = packageOption.Value();
+
+                    if (string.IsNullOrWhiteSpace(uriString)
+                        || string.IsNullOrWhiteSpace(apiKey)
+                        || string.IsNullOrWhiteSpace(package))
+                    {
+                        command.ShowHelp();
+                        return -1;
+                    }
+
+                    var server = new Uri(uriString).GetComponents(UriComponents.SchemeAndServer, UriFormat.Unescaped);
+
+                    var endpoint = new OctopusServerEndpoint(server, apiKey);
+                    var client = await OctopusAsyncClient.Create(endpoint);
+                    var repo = new OctopusAsyncRepository(client);
+
+                    var verbose = verboseOption.Value();
+
+                    if (verbose == "on")
+                    {
+                        Console.WriteLine($"server {server}");
+                        Console.WriteLine($"apiKey {apiKey}");
+                        Console.WriteLine($"package {package}");
+                        Console.Out.Flush();
+                    }
+
+                    using (var fileStream = File.OpenRead(package))
+                    {
+                        await repo.BuiltInPackageRepository.PushPackage(Path.GetFileName(package), fileStream);
+                    }
+
+                    return 0;
+                });
+        }
+
+        private static string GetAssemblyInformationalVersion()
+        {
+            var assembly = Assembly.GetEntryAssembly();
+            var attribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+            return attribute?.InformationalVersion;
+        }
+    }
+}

--- a/source/dotnet-octo/dotnet-octo.csproj
+++ b/source/dotnet-octo/dotnet-octo.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <PackageType>DotnetCliTool</PackageType>
+    <RootNamespace>OctoPack</RootNamespace>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Version>0.0.1</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.0" />
+    <PackageReference Include="Octopus.Client" Version="4.13.8" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This program currently only supports pack and push commands and can only pack zip files.

This is designed to replace the octo.exe in the new dotnet cli world. It can be used like this:

```
cd ./MyWebSite

dotnet publish --output "bin/publish"

dotnet octo pack --source-dir "bin/publish" --destination-dir "bin/OctopusPackage" --id "MyWebSite"

dotnet octo push --package "bin/OctopusPackage/*.zip" --server "https://MyOctopusServer" --api-key "blabla"
```