### PR TITLE
Fixes possible error when assembly uses GitVersion

### DIFF
--- a/source/OctoPack.Tasks/Util/AssemblyExtensions.cs
+++ b/source/OctoPack.Tasks/Util/AssemblyExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
@@ -24,11 +25,25 @@ public static class AssemblyExtensions
 
     public static string GetNugetVersionFromGitVersionInformation(this Assembly assembly)
     {
-        var types = assembly.GetTypes();
+        var types = assembly.GetLoadableTypes();
         var gitVersionInformationType = types.FirstOrDefault(t => string.Equals(t.Name, "GitVersionInformation"));
         if (gitVersionInformationType == null)
             return null;
         var versionField = gitVersionInformationType.GetField("NuGetVersion");
         return (string)versionField.GetValue(null);
+    }
+
+
+    public static IEnumerable<Type> GetLoadableTypes(this Assembly assembly)
+    {
+        if (assembly == null) throw new ArgumentNullException(nameof(assembly));
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException e)
+        {
+            return e.Types.Where(t => t != null);
+        }
     }
 }


### PR DESCRIPTION
This change fixes issues where an assembly is using GitVersion, but for some reason Octopack will not find the GitVersion information as some of the assemblys references cannot be loaded, thus the reflectionmethod "GetTypes()" throws an ReflectionTypeLoadException.

As Octopack only need to find the local type: "GitVersionInformation" it is okay to ignore any errors when trying to load referenced assemblies