### PR TITLE
[Fix] Support for Assembly Loading Failures

### DIFF
--- a/source/OctoPack.Tasks/GetAssemblyVersionInfo.cs
+++ b/source/OctoPack.Tasks/GetAssemblyVersionInfo.cs
@@ -55,7 +55,7 @@ namespace OctoPack.Tasks
             }
             catch (Exception ex)
             {
-                LogMessage(string.Format("Could load GitVersion information from the assembly at path {0}.", path), MessageImportance.Low);
+                LogMessage(string.Format("Could not load GitVersion information from the assembly at path {0}.", path), MessageImportance.Low);
                 LogMessage(ex.ToString(), MessageImportance.Low);
             }
 

--- a/source/OctoPack.Tasks/Util/AssemblyExtensions.cs
+++ b/source/OctoPack.Tasks/Util/AssemblyExtensions.cs
@@ -52,7 +52,14 @@ public static class AssemblyExtensions
 
     private static string GetNuGetVersionFromGitVersionInformation(this Assembly assembly)
     {
-        var types = assembly.GetTypes();
+        try
+        {
+            var types = assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            var types = ex.Types;
+        }
         var gitVersionInformationType = types.FirstOrDefault(t => string.Equals(t.Name, "GitVersionInformation"));
         if (gitVersionInformationType == null)
             return null;

--- a/source/OctoPack.Tasks/Util/AssemblyExtensions.cs
+++ b/source/OctoPack.Tasks/Util/AssemblyExtensions.cs
@@ -52,13 +52,14 @@ public static class AssemblyExtensions
 
     private static string GetNuGetVersionFromGitVersionInformation(this Assembly assembly)
     {
+        Type[] types;
         try
         {
-            var types = assembly.GetTypes();
+            types = assembly.GetTypes();
         }
         catch (ReflectionTypeLoadException ex)
         {
-            var types = ex.Types;
+            types = ex.Types;
         }
         var gitVersionInformationType = types.FirstOrDefault(t => string.Equals(t.Name, "GitVersionInformation"));
         if (gitVersionInformationType == null)

--- a/source/OctoPack.Tests.SampleGitVersionAssembly/OctoPack.Tests.SampleGitVersionAssembly.csproj
+++ b/source/OctoPack.Tests.SampleGitVersionAssembly/OctoPack.Tests.SampleGitVersionAssembly.csproj
@@ -60,7 +60,7 @@
     </PreBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PostBuildEvent>xcopy /y $(TargetPath) $(TargetDir)FileNotFoundException\</PostBuildEvent>
+    <PostBuildEvent>xcopy /y "$(TargetPath)" "$(TargetDir)FileNotFoundException\"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/source/OctoPack.Tests.SampleGitVersionAssembly/OctoPack.Tests.SampleGitVersionAssembly.csproj
+++ b/source/OctoPack.Tests.SampleGitVersionAssembly/OctoPack.Tests.SampleGitVersionAssembly.csproj
@@ -55,6 +55,13 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PreBuildEvent>
+    </PreBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /y $(TargetPath) $(TargetDir)FileNotFoundException\</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/source/OctoPack.Tests/Tasks/AssemblyExtensionsTests.cs
+++ b/source/OctoPack.Tests/Tasks/AssemblyExtensionsTests.cs
@@ -15,6 +15,14 @@ namespace OctoPack.Tests.Tasks
             return new FileInfo(assemblyPath).FullName;
         }
 
+        private string GetAssemblyFullExceptionPath(string name)
+        {
+            var currentAssemblyPath = Assembly.GetExecutingAssembly().FullLocalPath();
+            var configuration = new FileInfo(currentAssemblyPath).Directory.Name;
+            var assemblyPath = Path.Combine(currentAssemblyPath, "..", "..", "..", "..", name, "bin", configuration, "FileNotFoundException", $"{ name}.dll");
+            return new FileInfo(assemblyPath).FullName;
+        }
+
         [Test]
         public void AssertAssemblyVersion_WhereNoGitVersionProperty_ReturnsNull()
         {
@@ -27,6 +35,14 @@ namespace OctoPack.Tests.Tasks
         public void AssertAssemblyVersionGetsGitVersion()
         {
             var assemblyPath = GetAssemblyFullPath("OctoPack.Tests.SampleGitVersionAssembly");
+            var gitversion = AssemblyExtensions.GetNuGetVersionFromGitVersionInformation(assemblyPath);
+            Assert.That(gitversion, Is.EqualTo("1.1.1-tests"));
+        }
+
+        [Test]
+        public void AssertAssemblyFileNotFoundExceptionGetsGitVersion()
+        {
+            var assemblyPath = GetAssemblyFullExceptionPath("OctoPack.Tests.SampleGitVersionAssembly");
             var gitversion = AssemblyExtensions.GetNuGetVersionFromGitVersionInformation(assemblyPath);
             Assert.That(gitversion, Is.EqualTo("1.1.1-tests"));
         }


### PR DESCRIPTION
I ran into one of our Web Applications failing because of an external dependency not being loaded correctly inside the assembly. 

```
[21:03:40][GetAssemblyVersionInfo] Task Parameter:AssemblyFiles=C:\buildAgent\work\607dbd60a48f0770\src\Project\Project.Web.API\bin\Project.Web.API.dll
[21:03:40][GetAssemblyVersionInfo] OctoPack: Get version info from assembly: C:\buildAgent\work\607dbd60a48f0770\src\Project\Project.Web.API\bin\Project.Web.API.dll
[21:03:40][GetAssemblyVersionInfo] OctoPack: Could load GitVersion information from the assembly at path C:\buildAgent\work\607dbd60a48f0770\src\Project\Project.Web.API\bin\Project.Web.API.dll.
[21:03:40]
[GetAssemblyVersionInfo] OctoPack: System.Reflection.ReflectionTypeLoadException: Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
   at System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)
   at System.Reflection.RuntimeModule.GetTypes()
   at System.Reflection.Assembly.GetTypes()
   at AssemblyExtensions.GetNuGetVersionFromGitVersionInformation(Assembly assembly) in Z:\buildAgent\workDir\20ba9f2e0d5e4022\source\OctoPack.Tasks\Util\AssemblyExtensions.cs:line 55
   at AssemblyExtensions.GetNuGetVersionFromGitVersionInformation(String assemblyFullPath) in Z:\buildAgent\workDir\20ba9f2e0d5e4022\source\OctoPack.Tasks\Util\AssemblyExtensions.cs:line 33
   at OctoPack.Tasks.GetAssemblyVersionInfo.UseNuGetVersionFromGitVersionInformation(String path, FileVersionInfo info) in Z:\buildAgent\workDir\20ba9f2e0d5e4022\source\OctoPack.Tasks\GetAssemblyVersionInfo.cs:line 67
   at OctoPack.Tasks.GetAssemblyVersionInfo.CreateTaskItemFromFileVersionInfo(String path) in Z:\buildAgent\workDir\20ba9f2e0d5e4022\source\OctoPack.Tasks\GetAssemblyVersionInfo.cs:line 50
```
Which after debugging using the powershell script bellow


```
[CmdletBinding()]
Param ()
$DebugPreference = "Continue"

$PathToDLL = "C:\Windows\Temp\Project.Web.API.dll"

$Assembly = [System.Reflection.Assembly]::LoadFrom($PathToDLL);
$AssemblyName = $Assembly.GetName().Name
try {
$types = $assembly.GetTypes();
}
catch [System.Reflection.ReflectionTypeLoadException]
{
  Write-Debug "LoaderExceptions: $($_.Exception.LoaderExceptions)"
  Write-Warning "Loader Exception Occured"
  $types = $($_.Exception.Types)
}

$gitVersionInformationType = $types | Where-Object {$_.Name -eq "GitVersionInformation"}
if ($gitVersionInformationType -eq $null){
    Write-Warning "gitVersionInformation is null"
    return $null
}
$versionField = $gitVersionInformationType.GetField("NuGetVersion");
$versionField.GetValue($null);
```

Returns this multiple snippets with the same error.

``` 
DEBUG: LoaderExceptions: System.IO.FileNotFoundException: Could not load file or assembly 'System.Web.Http, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35' or one of its dependencies. The system cannot find the file specified.
File name: 'System.Web.Http, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
```

More information can be found [here](https://haacked.com/archive/2012/07/23/get-all-types-in-an-assembly.aspx/) about the implementation. Since there are no log messages in this file I am not sure if we should add one or not when this catch is caught.