### PR TITLE
Option to pack using project file

### DIFF
--- a/source/OctoPack.Tests/OctoPack.Tests.csproj
+++ b/source/OctoPack.Tests/OctoPack.Tests.csproj
@@ -103,7 +103,9 @@
     <Compile Include="Tasks\OctopusPhysicalFileSystemTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>

--- a/source/build/OctoPack.targets
+++ b/source/build/OctoPack.targets
@@ -38,6 +38,8 @@
     <OctoPackAppendProjectToFeed Condition="'$(OctoPackAppendProjectToFeed)' == ''">false</OctoPackAppendProjectToFeed>
     <OctoPackUseFileVersion Condition="'$(OctoPackUseFileVersion)' == ''">false</OctoPackUseFileVersion>
     <OctoPackUseProductVersion Condition="'$(OctoPackUseProductVersion)' == ''">false</OctoPackUseProductVersion>
+    <OctoPackPackUsingProject Condition="'$(OctoPackPackUsingProject)' == ''">false</OctoPackPackUsingProject>
+	<OctoPackProjectFullPath Condition="'$(OctoPackProjectFullPath)' == ''">$(MSBuildProjectFullPath)</OctoPackProjectFullPath>
   </PropertyGroup>
 
   <!-- 
@@ -94,6 +96,8 @@
       IncludeTypeScriptSourceFiles="$(OctoPackIncludeTypeScriptSourceFiles)"
       IgnoreNonRootScripts="$(OctoPackIgnoreNonRootScripts)"
       AppConfigFile="$(OctoPackAppConfigFileOverride)"
+	  PackUsingProject="$(OctoPackPackUsingProject)"
+	  ProjectFullPath="$(OctoPackProjectFullPath)"
       >
       <Output TaskParameter="Packages" ItemName="OctoPackBuiltPackages" />
       <Output TaskParameter="NuGetExePath" PropertyName="OctoPackNuGetExePath" />


### PR DESCRIPTION
Hello,

I tried to use the powerful OctoPack task to generate NuGet packages for our libraries projects but the generated packages were not correct. The binary files (.dll) file are not put in "lib/{framework_version}" folder in the package. As consequence, the package could not be imported on other projects.

In order to fix this, I wanted to be able to create a package based on the project file instead of the .nuspec file (as the nuget.exe allow it). So, I add a new boolean parameter "PackUsingProject" (default to false).
When this parameter is true, OctoPack call the "nuget.exe" command with the project file as parameter (instead of .nuspec) and with the "-Build" option. With this option, the compiled binaries are automaticly put in the "lib/{framework_version}" folder (which is not like this with default OctoPack behavior).

New command parameter example
`msbuild mySolution.sln  /t:Rebuild /p:Configuration=Release /p:RunOctoPack=true /p:OctoPackPackUsingProject=true`

The result is that the generated NuGet package has a correct structure to be push to a classic NuGet server and they are "consumable as standard Nuget packages."

Maybe more test need to be done on this feature but it could be very great and useful to have it integrated natively to OctoPack. ([ex of related ticket](https://help.octopusdeploy.com/discussions/questions/7863-can-octopack-be-used-to-create-consumable-nuget-packages) mentioned on your support).

