### PR TITLE
Allow metadata-only AppendToVersion

### DIFF
--- a/source/OctoPack.Tasks/CreateOctoPackPackage.cs
+++ b/source/OctoPack.Tasks/CreateOctoPackPackage.cs
@@ -401,7 +401,11 @@ namespace OctoPack.Tasks
 
             var version = GetVersionElementFromNuSpec(nuSpec);
 
-            version.Value = $"{PackageVersion ?? version.Value}-{AppendToVersion.Trim()}";
+            if (AppendToVersion[0] != '+')
+                version.Value = $"{PackageVersion ?? version.Value}-{AppendToVersion.Trim()}";
+            else
+                version.Value = $"{PackageVersion ?? version.Value}{AppendToVersion.Trim()}";
+
             PackageVersion = version.Value;
         }
 

--- a/source/OctoPack.Tests/Integration/SampleSolutionBuildFixture.cs
+++ b/source/OctoPack.Tests/Integration/SampleSolutionBuildFixture.cs
@@ -495,6 +495,54 @@ namespace OctoPack.Tests.Integration
         }
 
         [Test]
+        public void ShouldAllowAppendingValueToVersionWithMetadataOnly()
+        {
+            MsBuild("Samples.sln /p:RunOctoPack=true /p:OctoPackAppendToVersion=+Foo /p:Configuration=Release /v:m");
+
+            AssertPackage(@"Sample.ConsoleApp\obj\octopacked\Sample.ConsoleApp.2.1.0.1+Foo.nupkg",
+                pkg => pkg.AssertContents(
+                    "Sample.ConsoleApp.exe",
+                    "Sample.ConsoleApp.exe.config",
+                    "Sample.ConsoleApp.pdb"));
+
+            AssertPackage(@"Sample.WebApp\obj\octopacked\Sample.WebApp.3.1.0-dev+Foo.nupkg",
+                pkg => pkg.AssertContents(
+                    "bin\\*.dll",
+                    "bin\\*.xml",
+                    "bin\\Sample.WebApp.dll",
+                    "bin\\Sample.WebApp.pdb",
+                    "Content\\*.css",
+                    "Content\\*.png",
+                    "Content\\LinkedFile.txt",
+                    "Scripts\\*.js",
+                    "Views\\Web.config",
+                    "Views\\*.cshtml",
+                    "Global.asax",
+                    "Web.config",
+                    "Web.Release.config",
+                    "Web.Debug.config"));
+
+            AssertPackage(@"Sample.WebAppWithSpec\obj\octopacked\Sample.WebAppWithSpec.1.0.13-demo+Foo.nupkg",
+                pkg => pkg.AssertContents(
+                    "bin\\*.dll",
+                    "bin\\*.xml",
+                    "bin\\Sample.WebAppWithSpec.dll",
+                    "bin\\Sample.WebAppWithSpec.pdb",
+                    "Content\\*.css",
+                    "Content\\*.png",
+                    "Content\\LinkedFile.txt",
+                    "Scripts\\*.js",
+                    "Views\\Web.config",
+                    "Views\\*.cshtml",
+                    "Views\\Deploy.ps1",
+                    "Deploy.ps1",
+                    "Global.asax",
+                    "Web.config",
+                    "Web.Release.config",
+                    "Web.Debug.config"));
+        }
+
+        [Test]
         public void ShouldSupportRelativeOutputDirectories()
         {
             MsBuild("Sample.ConsoleWithRelativeOutDir\\Sample.ConsoleWithRelativeOutDir.csproj /p:RunOctoPack=true /p:OctoPackPackageVersion=1.0.11 /p:Configuration=Release");


### PR DESCRIPTION
Allows AppendToVersion that is metadata-only, which is considered a valid version number in SemVer 2.0.

Allows resulting versions such as: 1.2.3.4+build.123.sha.ceb8c19b .