### PR TITLE
Fixes *.csproj.CopyComplete files from being included in OctoPack packages

### DIFF
--- a/source/OctoPack.Tests/Integration/BuildFixture.cs
+++ b/source/OctoPack.Tests/Integration/BuildFixture.cs
@@ -56,13 +56,22 @@ namespace OctoPack.Tests.Integration
         private static string GetMsBuildPath()
         {
             string msBuild;
+
             var programFilesDirectory = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
-            foreach (var version in new []{"14.0","12.0"})
+            foreach (var version in new[] { "Current", "15.0", "14.0", "12.0" })
             {
-                var buildDirectory = Path.Combine(programFilesDirectory, "MSBuild", version, "Bin");
-                msBuild = Path.Combine(buildDirectory, "msbuild.exe");
-                if (File.Exists(msBuild))
-                    return msBuild;
+                // As of Visual Studio 2017, Microsoft changed where the MSBuild tools reside. As of Visual Studio 2019, Microsoft stopped using
+                // a version number, such as 15.0, in the path and now uses 'Current'.
+                // This additional loop accounts for MSBuild located in the Visual Studio installation path for both VS2017 and VS2019 Professional
+                // and enterprise editions. This is still fragile, as there are other editions of Visual Studio, and also does not account for
+                // the Visual Studio Build Tools (for 2017 and 2019).
+                // The last empty string array entry is for Visual Studio 2015 and below.
+                foreach (var msBuildBasePath in new[] { "Microsoft Visual Studio\\2019\\Professional", "Microsoft Visual Studio\\2019\\Enterprise", "Microsoft Visual Studio\\2017\\Professional", "Microsoft Visual Studio\\2017\\Enterprise", "" })
+                {
+                    msBuild = Path.Combine(programFilesDirectory, msBuildBasePath, "MSBuild", version, "Bin", "msbuild.exe");
+                    if (File.Exists(msBuild))
+                        return msBuild;
+                }
             }
             var netFx = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
             msBuild = Path.Combine(netFx, "msbuild.exe");

--- a/source/OctoPack.Tests/Integration/SampleSolutionBuildFixture.cs
+++ b/source/OctoPack.Tests/Integration/SampleSolutionBuildFixture.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 
 namespace OctoPack.Tests.Integration
 {
-    [TestFixture]
+    [TestFixture, Category("Integration Tests")]
     public class SampleSolutionBuildFixture : BuildFixture
     {
         [Test]
@@ -13,7 +13,7 @@ namespace OctoPack.Tests.Integration
         {
             MsBuild("Samples.sln /p:RunOctoPack=true /p:OctoPackPackageVersion=1.0.9 /p:Configuration=Release /v:m");
 
-            AssertPackage(@"Sample.ConsoleApp\obj\octopacked\Sample.ConsoleApp.1.0.9.nupkg", 
+            AssertPackage(@"Sample.ConsoleApp\obj\octopacked\Sample.ConsoleApp.1.0.9.nupkg",
                 pkg => pkg.AssertContents(
                     "Sample.ConsoleApp.exe",
                     "Sample.ConsoleApp.exe.config",

--- a/source/build/OctoPack.targets
+++ b/source/build/OctoPack.targets
@@ -9,7 +9,7 @@
       OctoPack
     </BuildDependsOn>
   </PropertyGroup>
-  
+
   <!--
   Configuration properties - you can override these from the command line
   -->
@@ -40,7 +40,7 @@
     <OctoPackUseProductVersion Condition="'$(OctoPackUseProductVersion)' == ''">false</OctoPackUseProductVersion>
   </PropertyGroup>
 
-  <!-- 
+  <!--
   Create Octopus Deploy package
   -->
   <Target Name="OctoPack" Condition="$(RunOctoPack)">
@@ -67,13 +67,13 @@
 
     <ItemGroup>
 
-      <OctoPackWrittenFiles Include="@(FileWrites)" Exclude="$(IntermediateOutputPath)**\*" />
+      <OctoPackWrittenFiles Include="@(FileWrites)" Exclude="$(IntermediateOutputPath)**\*;@(CopyUpToDateMarker)" />
       <OctoPackWrittenFiles Include="@(FileWritesShareable)" Exclude="$(IntermediateOutputPath)**\*" />
-      
+
       <OctoPackContentFiles Include="@(Content)" />
       <OctoPackContentFiles Include="@(TypeScriptCompile)" />
     </ItemGroup>
-    
+
     <CreateOctoPackPackage
       NuSpecFileName="$(OctoPackNuSpecFileName)"
       AppendToPackageId="$(OctoPackAppendToPackageId)"


### PR DESCRIPTION
The organization I currently work for recently had a spate of deployment failures when Octopus Deploy attempted to transform some application configuration files. After a few days' time, we finally determined that this internal Octopus Deploy process was responsible for the deployment failures because it does a directory scan looking for files to transform. One of the file's absolute path in the extracted deployment package location exceeded `MAX_PATH` characters.

The file exceeding the `MAX_PATH` length was a 0-byte text file that is created during builds made with Visual Studio (Build Tools) 2017/2019 as a result of [this dotnet/msbuild pull request](https://github.com/dotnet/msbuild/pull/2878). This was not caught with the most recent release of OctoPack (v3.6.4 on 14 Jan. 2019) because the unit tests were never updated to use newer versions of the MSBuild build tools.

This pull request updates the unit tests to attempt to find newer versions of the MSBuild build tools (it's still hard-coded and will only work up to Visual Studio 2019) and use those first over older build tools. In addition, the `OctoPack.targets` file was updated to exclude this extraneous file from being packaged by OctoPack.